### PR TITLE
Add thumbnail test

### DIFF
--- a/fixtures/schematron/invalid_empty_identifier1.xml
+++ b/fixtures/schematron/invalid_empty_identifier1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edm="http://www.europeana.eu/schemas/edm/"
+  xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+  xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+  xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+  xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+  <dcterms:title>Celebration at Independence Hall</dcterms:title>
+  <dcterms:creator>pdcp_noharvest</dcterms:creator>
+  <dcterms:publisher>Philadelphia Evening Bulletin</dcterms:publisher>
+  <dcterms:description>Photo shows pennants and streamers hanging from clock and bell tower
+    of Independence Hall and Commodore John Barry monument. There is a tent and loud speaker
+    system immediately in front of Independence Hall entrance. Note dirigible in left upper
+    quadrant of photo.</dcterms:description>
+  <dcterms:spatial>Philadelphia (Pa.);Independence National Historical Park (Philadelphia,
+    Pa.)</dcterms:spatial>
+  <dcterms:date>1924</dcterms:date>
+  <dcterms:subject>Statues</dcterms:subject>
+  <dcterms:type>Image</dcterms:type>
+  <dcterms:rights>This material is made available for private study, scholarship, and
+    research use. For access to the original, contact: Temple University Libraries. Special
+    Collections Research Center, scrc@temple.edu, 215-204-8257.</dcterms:rights>
+  <schema:fileFormat>image/jp2</schema:fileFormat>
+  <dcterms:identifier/>
+  <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/0</edm:isShownAt>
+  <edm:preview>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/0/tnail</edm:preview>
+  <edm:dataProvider>Temple University</edm:dataProvider>
+  <edm:provider>PA Digital</edm:provider>
+</oai_dc:dc>

--- a/fixtures/schematron/invalid_empty_identifier2.xml
+++ b/fixtures/schematron/invalid_empty_identifier2.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edm="http://www.europeana.eu/schemas/edm/"
+  xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+  xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+  xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+  xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+  <dcterms:title>Celebration at Independence Hall</dcterms:title>
+  <dcterms:creator>pdcp_noharvest</dcterms:creator>
+  <dcterms:publisher>Philadelphia Evening Bulletin</dcterms:publisher>
+  <dcterms:description>Photo shows pennants and streamers hanging from clock and bell tower
+    of Independence Hall and Commodore John Barry monument. There is a tent and loud speaker
+    system immediately in front of Independence Hall entrance. Note dirigible in left upper
+    quadrant of photo.</dcterms:description>
+  <dcterms:spatial>Philadelphia (Pa.);Independence National Historical Park (Philadelphia,
+    Pa.)</dcterms:spatial>
+  <dcterms:date>1924</dcterms:date>
+  <dcterms:subject>Statues</dcterms:subject>
+  <dcterms:type>Image</dcterms:type>
+  <dcterms:rights>This material is made available for private study, scholarship, and
+    research use. For access to the original, contact: Temple University Libraries. Special
+    Collections Research Center, scrc@temple.edu, 215-204-8257.</dcterms:rights>
+  <schema:fileFormat>image/jp2</schema:fileFormat>
+  <dcterms:identifier></dcterms:identifier>
+  <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/0</edm:isShownAt>
+  <edm:preview>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/0/tnail</edm:preview>
+  <edm:dataProvider>Temple University</edm:dataProvider>
+  <edm:provider>PA Digital</edm:provider>
+</oai_dc:dc>

--- a/fixtures/schematron/invalid_empty_thumbnailURL1.xml
+++ b/fixtures/schematron/invalid_empty_thumbnailURL1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edm="http://www.europeana.eu/schemas/edm/"
+  xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+  xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+  xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+  xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+  <dcterms:title>Celebration at Independence Hall</dcterms:title>
+  <dcterms:creator>pdcp_noharvest</dcterms:creator>
+  <dcterms:publisher>Philadelphia Evening Bulletin</dcterms:publisher>
+  <dcterms:description>Photo shows pennants and streamers hanging from clock and bell tower
+    of Independence Hall and Commodore John Barry monument. There is a tent and loud speaker
+    system immediately in front of Independence Hall entrance. Note dirigible in left upper
+    quadrant of photo.</dcterms:description>
+  <dcterms:spatial>Philadelphia (Pa.);Independence National Historical Park (Philadelphia,
+    Pa.)</dcterms:spatial>
+  <dcterms:date>1924</dcterms:date>
+  <dcterms:subject>Statues</dcterms:subject>
+  <dcterms:type>Image</dcterms:type>
+  <dcterms:rights>This material is made available for private study, scholarship, and
+    research use. For access to the original, contact: Temple University Libraries. Special
+    Collections Research Center, scrc@temple.edu, 215-204-8257.</dcterms:rights>
+  <schema:fileFormat>image/jp2</schema:fileFormat>
+  <dcterms:identifier>P288153B</dcterms:identifier>
+  <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/0</edm:isShownAt>
+  <edm:preview/>
+  <edm:dataProvider>Temple University</edm:dataProvider>
+  <edm:provider>PA Digital</edm:provider>
+</oai_dc:dc>

--- a/fixtures/schematron/invalid_empty_thumbnailURL2.xml
+++ b/fixtures/schematron/invalid_empty_thumbnailURL2.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edm="http://www.europeana.eu/schemas/edm/"
+  xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+  xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+  xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+  xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+  <dcterms:title>Celebration at Independence Hall</dcterms:title>
+  <dcterms:creator>pdcp_noharvest</dcterms:creator>
+  <dcterms:publisher>Philadelphia Evening Bulletin</dcterms:publisher>
+  <dcterms:description>Photo shows pennants and streamers hanging from clock and bell tower
+    of Independence Hall and Commodore John Barry monument. There is a tent and loud speaker
+    system immediately in front of Independence Hall entrance. Note dirigible in left upper
+    quadrant of photo.</dcterms:description>
+  <dcterms:spatial>Philadelphia (Pa.);Independence National Historical Park (Philadelphia,
+    Pa.)</dcterms:spatial>
+  <dcterms:date>1924</dcterms:date>
+  <dcterms:subject>Statues</dcterms:subject>
+  <dcterms:type>Image</dcterms:type>
+  <dcterms:rights>This material is made available for private study, scholarship, and
+    research use. For access to the original, contact: Temple University Libraries. Special
+    Collections Research Center, scrc@temple.edu, 215-204-8257.</dcterms:rights>
+  <schema:fileFormat>image/jp2</schema:fileFormat>
+  <dcterms:identifier>P288153B</dcterms:identifier>
+  <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/0</edm:isShownAt>
+  <edm:preview></edm:preview>
+  <edm:dataProvider>Temple University</edm:dataProvider>
+  <edm:provider>PA Digital</edm:provider>
+</oai_dc:dc>

--- a/fixtures/schematron/invalid_missing_identifier.xml
+++ b/fixtures/schematron/invalid_missing_identifier.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edm="http://www.europeana.eu/schemas/edm/"
+  xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+  xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+  xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+  xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+  <dcterms:title>Celebration at Independence Hall</dcterms:title>
+  <dcterms:creator>pdcp_noharvest</dcterms:creator>
+  <dcterms:publisher>Philadelphia Evening Bulletin</dcterms:publisher>
+  <dcterms:description>Photo shows pennants and streamers hanging from clock and bell tower
+    of Independence Hall and Commodore John Barry monument. There is a tent and loud speaker
+    system immediately in front of Independence Hall entrance. Note dirigible in left upper
+    quadrant of photo.</dcterms:description>
+  <dcterms:spatial>Philadelphia (Pa.);Independence National Historical Park (Philadelphia,
+    Pa.)</dcterms:spatial>
+  <dcterms:date>1924</dcterms:date>
+  <dcterms:subject>Statues</dcterms:subject>
+  <dcterms:type>Image</dcterms:type>
+  <dcterms:rights>This material is made available for private study, scholarship, and
+    research use. For access to the original, contact: Temple University Libraries. Special
+    Collections Research Center, scrc@temple.edu, 215-204-8257.</dcterms:rights>
+  <schema:fileFormat>image/jp2</schema:fileFormat>
+  <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/0</edm:isShownAt>
+  <edm:preview>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/0/tnail</edm:preview>
+  <edm:dataProvider>Temple University</edm:dataProvider>
+  <edm:provider>PA Digital</edm:provider>
+</oai_dc:dc>

--- a/fixtures/schematron/invalid_missing_thumbnailURL.xml
+++ b/fixtures/schematron/invalid_missing_thumbnailURL.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edm="http://www.europeana.eu/schemas/edm/"
+  xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+  xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+  xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+  xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+  <dcterms:title>Celebration at Independence Hall</dcterms:title>
+  <dcterms:creator>pdcp_noharvest</dcterms:creator>
+  <dcterms:publisher>Philadelphia Evening Bulletin</dcterms:publisher>
+  <dcterms:description>Photo shows pennants and streamers hanging from clock and bell tower
+    of Independence Hall and Commodore John Barry monument. There is a tent and loud speaker
+    system immediately in front of Independence Hall entrance. Note dirigible in left upper
+    quadrant of photo.</dcterms:description>
+  <dcterms:spatial>Philadelphia (Pa.);Independence National Historical Park (Philadelphia,
+    Pa.)</dcterms:spatial>
+  <dcterms:date>1924</dcterms:date>
+  <dcterms:subject>Statues</dcterms:subject>
+  <dcterms:type>Image</dcterms:type>
+  <dcterms:rights>This material is made available for private study, scholarship, and
+    research use. For access to the original, contact: Temple University Libraries. Special
+    Collections Research Center, scrc@temple.edu, 215-204-8257.</dcterms:rights>
+  <schema:fileFormat>image/jp2</schema:fileFormat>
+  <dcterms:identifier>P288153B</dcterms:identifier>
+  <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/0</edm:isShownAt>
+  <edm:dataProvider>Temple University</edm:dataProvider>
+  <edm:provider>PA Digital</edm:provider>
+</oai_dc:dc>

--- a/fixtures/schematron/valid_dct_identifier.xml
+++ b/fixtures/schematron/valid_dct_identifier.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edm="http://www.europeana.eu/schemas/edm/"
+  xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+  xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+  xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+  xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+  <dcterms:title>Celebration at Independence Hall</dcterms:title>
+  <dcterms:creator>pdcp_noharvest</dcterms:creator>
+  <dcterms:publisher>Philadelphia Evening Bulletin</dcterms:publisher>
+  <dcterms:description>Photo shows pennants and streamers hanging from clock and bell tower
+    of Independence Hall and Commodore John Barry monument. There is a tent and loud speaker
+    system immediately in front of Independence Hall entrance. Note dirigible in left upper
+    quadrant of photo.</dcterms:description>
+  <dcterms:spatial>Philadelphia (Pa.);Independence National Historical Park (Philadelphia,
+    Pa.)</dcterms:spatial>
+  <dcterms:date>1924</dcterms:date>
+  <dcterms:subject>Statues</dcterms:subject>
+  <dcterms:type>Image</dcterms:type>
+  <dcterms:rights>This material is made available for private study, scholarship, and
+    research use. For access to the original, contact: Temple University Libraries. Special
+    Collections Research Center, scrc@temple.edu, 215-204-8257.</dcterms:rights>
+  <schema:fileFormat>image/jp2</schema:fileFormat>
+  <dcterms:identifier>P288153B</dcterms:identifier>
+  <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/0</edm:isShownAt>
+  <edm:preview>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/0/tnail</edm:preview>
+  <edm:dataProvider>Temple University</edm:dataProvider>
+  <edm:provider>PA Digital</edm:provider>
+</oai_dc:dc>

--- a/fixtures/schematron/valid_dct_identifier_pattern.xml
+++ b/fixtures/schematron/valid_dct_identifier_pattern.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edm="http://www.europeana.eu/schemas/edm/"
+  xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+  xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+  xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+  xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+  <dcterms:title>Celebration at Independence Hall</dcterms:title>
+  <dcterms:creator>pdcp_noharvest</dcterms:creator>
+  <dcterms:publisher>Philadelphia Evening Bulletin</dcterms:publisher>
+  <dcterms:description>Photo shows pennants and streamers hanging from clock and bell tower
+    of Independence Hall and Commodore John Barry monument. There is a tent and loud speaker
+    system immediately in front of Independence Hall entrance. Note dirigible in left upper
+    quadrant of photo.</dcterms:description>
+  <dcterms:spatial>Philadelphia (Pa.);Independence National Historical Park (Philadelphia,
+    Pa.)</dcterms:spatial>
+  <dcterms:date>1924</dcterms:date>
+  <dcterms:subject>Statues</dcterms:subject>
+  <dcterms:type>Image</dcterms:type>
+  <dcterms:rights>This material is made available for private study, scholarship, and
+    research use. For access to the original, contact: Temple University Libraries. Special
+    Collections Research Center, scrc@temple.edu, 215-204-8257.</dcterms:rights>
+  <schema:fileFormat>image/jp2</schema:fileFormat>
+  <dcterms:identifier>P288153B</dcterms:identifier>
+  <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/0</edm:isShownAt>
+  <edm:preview>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/0/tnail</edm:preview>
+  <edm:dataProvider>Temple University</edm:dataProvider>
+  <edm:provider>PA Digital</edm:provider>
+</oai_dc:dc>

--- a/fixtures/schematron/valid_edm_preview.xml
+++ b/fixtures/schematron/valid_edm_preview.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edm="http://www.europeana.eu/schemas/edm/"
+  xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+  xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+  xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+  xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+  <dcterms:title>Celebration at Independence Hall</dcterms:title>
+  <dcterms:creator>pdcp_noharvest</dcterms:creator>
+  <dcterms:publisher>Philadelphia Evening Bulletin</dcterms:publisher>
+  <dcterms:description>Photo shows pennants and streamers hanging from clock and bell tower
+    of Independence Hall and Commodore John Barry monument. There is a tent and loud speaker
+    system immediately in front of Independence Hall entrance. Note dirigible in left upper
+    quadrant of photo.</dcterms:description>
+  <dcterms:spatial>Philadelphia (Pa.);Independence National Historical Park (Philadelphia,
+    Pa.)</dcterms:spatial>
+  <dcterms:date>1924</dcterms:date>
+  <dcterms:subject>Statues</dcterms:subject>
+  <dcterms:type>Image</dcterms:type>
+  <dcterms:rights>This material is made available for private study, scholarship, and
+    research use. For access to the original, contact: Temple University Libraries. Special
+    Collections Research Center, scrc@temple.edu, 215-204-8257.</dcterms:rights>
+  <schema:fileFormat>image/jp2</schema:fileFormat>
+  <dcterms:identifier>P288153B</dcterms:identifier>
+  <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/0</edm:isShownAt>
+  <edm:preview>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/0/tnail</edm:preview>
+  <edm:dataProvider>Temple University</edm:dataProvider>
+  <edm:provider>PA Digital</edm:provider>
+</oai_dc:dc>

--- a/fixtures/schematron/valid_edm_preview_pattern.xml
+++ b/fixtures/schematron/valid_edm_preview_pattern.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edm="http://www.europeana.eu/schemas/edm/"
+  xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+  xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+  xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+  xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+  <dcterms:title>Celebration at Independence Hall</dcterms:title>
+  <dcterms:creator>pdcp_noharvest</dcterms:creator>
+  <dcterms:publisher>Philadelphia Evening Bulletin</dcterms:publisher>
+  <dcterms:description>Photo shows pennants and streamers hanging from clock and bell tower
+    of Independence Hall and Commodore John Barry monument. There is a tent and loud speaker
+    system immediately in front of Independence Hall entrance. Note dirigible in left upper
+    quadrant of photo.</dcterms:description>
+  <dcterms:spatial>Philadelphia (Pa.);Independence National Historical Park (Philadelphia,
+    Pa.)</dcterms:spatial>
+  <dcterms:date>1924</dcterms:date>
+  <dcterms:subject>Statues</dcterms:subject>
+  <dcterms:type>Image</dcterms:type>
+  <dcterms:rights>This material is made available for private study, scholarship, and
+    research use. For access to the original, contact: Temple University Libraries. Special
+    Collections Research Center, scrc@temple.edu, 215-204-8257.</dcterms:rights>
+  <schema:fileFormat>image/jp2</schema:fileFormat>
+  <dcterms:identifier>P288153B</dcterms:identifier>
+  <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/0</edm:isShownAt>
+  <edm:preview>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/0/tnail</edm:preview>
+  <edm:dataProvider>Temple University</edm:dataProvider>
+  <edm:provider>PA Digital</edm:provider>
+</oai_dc:dc>

--- a/tests/schematron/padigital_missing_thumbnailURL.xspec
+++ b/tests/schematron/padigital_missing_thumbnailURL.xspec
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+  schematron="../../validations/padigital_missing_thumbnailURL.sch">
+  <x:scenario label="RequiredElementsPattern">
+    <x:scenario label="valid: edm:preview">
+      <x:context href="../../fixtures/schematron/valid_edm_preview.xml"/>
+      <x:expect-valid/>
+    </x:scenario>
+    <x:scenario label="not valid: missing edm:preview">
+      <x:context href="../../fixtures/schematron/invalid_missing_thumbnailURL.xml"/>
+      <x:expect-assert id="Required1"/>
+    </x:scenario>
+  </x:scenario>
+  <x:scenario label="ThumbnailURLElementPattern">
+    <x:scenario label="valid">
+      <x:context href="../../fixtures/schematron/valid_edm_preview_pattern.xml"/>
+      <x:expect-valid/>
+    </x:scenario>
+    <x:scenario label="not valid">
+      <x:scenario label="not valid: empty thumbnail 1">
+        <x:context href="../../fixtures/schematron/invalid_empty_thumbnailURL1.xml"/>
+        <x:expect-assert id="ThumbnailURL1"/>
+      </x:scenario>
+      <x:scenario label="not valid: empty thumbnail 2">
+        <x:context href="../../fixtures/schematron/invalid_empty_thumbnailURL2.xml"/>
+        <x:expect-assert id="ThumbnailURL1"/>
+      </x:scenario>
+    <x:scenario>
+  </x:scenario>
+</x:description>


### PR DESCRIPTION
.xpec and fixtures to accompany padigital_missing_thumbnailURL.sch