### PR TITLE
add test and fixtures for dcingest_reqd_fields

### DIFF
--- a/fixtures/schematron/invalid_RelNoHarvest.xml
+++ b/fixtures/schematron/invalid_RelNoHarvest.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:title>Railroad stock certificate collection 1857-1970</dc:title>
+    <dc:subject>Allegheny Valley Railroad Company.</dc:subject>
+    <dc:subject>Pennsylvania Railroad.</dc:subject>
+    <dc:subject>Pittsburgh and Lake Erie Railroad Company.</dc:subject>
+    <dc:subject>Business and Industry</dc:subject>
+    <dc:subject>Railroad companies--Pennsylvania</dc:subject>
+    <dc:subject>Railroads</dc:subject>
+    <dc:subject>Transportation</dc:subject>
+    <dc:description>This collection contains 51 stock certificates dating from 1857 to 1970 documenting the history of railroads in western Pennsylvania. Also included are various items such as correspondence, bills of lading, telegrams, valuation of baggage tickets, dividend check, a lease, and employee transit passes for the Pennsylvania Railroad Lines West of Pittsburgh. Digital reproductions of the stock certificates are available online.</dc:description>
+    <dc:description>Railroad Stock Certificate Collection, AIS.2015.06, 1857-1970, Archives Service Center, University of Pittsburgh</dc:description>
+    <dc:description>Digital reproductions of the collection are available online.</dc:description>
+    <dc:description>Gift; Ken Kobus; 201506.</dc:description>
+    <dc:description>The beginning of the Pennsylvania Railroad (PRR and sometimes referred to as the Pennsy) was indicative of the complex industrial, political, and geographical conditions experienced by the railroad during the formative period of railroad development in the United States. Legal constraints also played an early role in the organization of the railroad.   The original 1846 charter granted the Pennsylvania Railroad rights to build a line from the western terminus of the Harrisburg, Portsmouth, Mount Joy and Lancaster Railroad in the State Capital to Pittsburgh or elsewhere in Allegheny County. Extending the railroad west of Pittsburgh created controversy with some stockholders of the Pennsylvania Railroad proper and so was approached through various associations with other railroads, i.e., outright ownership, leases or other means of control, developing a &#8304;&#769;&#8331;Lines East/Lines West&#8304;&#769;&#8330; operating scheme. When the PRR began building in 1847, Pittsburgh was uniquely positioned by its location at the headwaters of the Ohio River with its connection to the Mississippi and Missouri and the extensive river network extending southward to New Orleans and westward to the far reaches of the Missouri River in Montana.   When the Pennsylvania Railroad began rail operations to Pittsburgh in 1852 through rail lines and inclined planes, it began by using portions of the Allegheny Portage RR. Also in 1852, the PRR hired J. Edgar Thomson from the Georgia Railroad to survey and build the line. Thomson served at the Pennsylvania Railroad&#8304;&#769;&#8329;s first engineer and third president responsible for making the PRR a technological innovator until his death in 1874. His work created the layout of the railroad to Pittsburgh as well as the famed Horseshoe Curve in Altoona which opened in 1854. The opening of Horseshoe Curve reduced travel time between Pittsburgh and Philadelphia from a little over three days to 13 hours.   By 1854, all rail lines were completed to Pittsburgh. Lines ran from Philadelphia to Pittsburgh, connecting through Harrisburg. The PRR continued to grow and expand throughout the Nineteenth Century and by the mid-1920s occupied over 10,000 miles of track. The Pennsylvania Railroad merged with the NY Central in 1968 and filed for bankruptcy about two years later. By 1976, assets would be split between Conrail, the Norfolk Southern Railway, and with electrified track east of Harrisburg becoming part of Amtrak.   For a complete history of the Pennsylvania Railroad, please see:   Kobus, Ken, and Jack Consoli. 1996. The Pennsy in the steel city: 150 years of the Pennsylvania Railroad in Pittsburgh. Upper Darby, PA (P.O. Box 389, Upper Darby 19082): Pennsylvania Railroad Technical and Historical Society.</dc:description>
+    <dc:contributor>University of Pittsburgh (depositor)</dc:contributor>
+    <dc:date>1857-1970</dc:date>
+    <dc:type>Collection</dc:type>
+    <dc:type>text</dc:type>
+    <dc:type>Stock certificates</dc:type>
+    <dc:type>Finding aids.</dc:type>
+    <dc:identifier>pitt:US-PPiU-ais201506</dc:identifier>
+    <dc:language>eng</dc:language>
+    <dc:relation>http://digital.library.pitt.edu/cgi-bin/f/findaid/findaid-idx?type=simple;c=ascead;view=text;subview=outline;didno=US-PPiU-ais201506</dc:relation>
+    <dc:relation>pdcp_noharvest</dc:relation>
+    <dc:coverage>Pennsylvania</dc:coverage>
+    <dc:rights>Copyright Not Evaluated. The copyright and related rights status of this Item has not been evaluated. Please refer to the organization that has made the Item available for more information. You are free to use this Item in any way that is permitted by the copyright and related rights legislation that applies to your use.</dc:rights>
+    <dc:rights>http://rightsstatements.org/vocab/CNE/1.0/</dc:rights>
+    <dc:rights>Copyright Not Evaluated. The copyright and related rights status of this Item has not been evaluated. Please refer to the organization that has made the Item available for more information. You are free to use this Item in any way that is permitted by the copyright and related rights legislation that applies to your use.</dc:rights>
+    <dc:rights>http://rightsstatements.org/vocab/CNE/1.0/</dc:rights>
+    <identifier>http://historicpittsburgh.org/islandora/object/pitt%3AUS-PPiU-ais201506</identifier>
+</oai_dc:dc>

--- a/fixtures/schematron/invalid_RightsNoHarvest.xml
+++ b/fixtures/schematron/invalid_RightsNoHarvest.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:title>Railroad stock certificate collection 1857-1970</dc:title>
+    <dc:subject>Allegheny Valley Railroad Company.</dc:subject>
+    <dc:subject>Pennsylvania Railroad.</dc:subject>
+    <dc:subject>Pittsburgh and Lake Erie Railroad Company.</dc:subject>
+    <dc:subject>Business and Industry</dc:subject>
+    <dc:subject>Railroad companies--Pennsylvania</dc:subject>
+    <dc:subject>Railroads</dc:subject>
+    <dc:subject>Transportation</dc:subject>
+    <dc:description>This collection contains 51 stock certificates dating from 1857 to 1970 documenting the history of railroads in western Pennsylvania. Also included are various items such as correspondence, bills of lading, telegrams, valuation of baggage tickets, dividend check, a lease, and employee transit passes for the Pennsylvania Railroad Lines West of Pittsburgh. Digital reproductions of the stock certificates are available online.</dc:description>
+    <dc:description>Railroad Stock Certificate Collection, AIS.2015.06, 1857-1970, Archives Service Center, University of Pittsburgh</dc:description>
+    <dc:description>Digital reproductions of the collection are available online.</dc:description>
+    <dc:description>Gift; Ken Kobus; 201506.</dc:description>
+    <dc:description>The beginning of the Pennsylvania Railroad (PRR and sometimes referred to as the Pennsy) was indicative of the complex industrial, political, and geographical conditions experienced by the railroad during the formative period of railroad development in the United States. Legal constraints also played an early role in the organization of the railroad.   The original 1846 charter granted the Pennsylvania Railroad rights to build a line from the western terminus of the Harrisburg, Portsmouth, Mount Joy and Lancaster Railroad in the State Capital to Pittsburgh or elsewhere in Allegheny County. Extending the railroad west of Pittsburgh created controversy with some stockholders of the Pennsylvania Railroad proper and so was approached through various associations with other railroads, i.e., outright ownership, leases or other means of control, developing a &#8304;&#769;&#8331;Lines East/Lines West&#8304;&#769;&#8330; operating scheme. When the PRR began building in 1847, Pittsburgh was uniquely positioned by its location at the headwaters of the Ohio River with its connection to the Mississippi and Missouri and the extensive river network extending southward to New Orleans and westward to the far reaches of the Missouri River in Montana.   When the Pennsylvania Railroad began rail operations to Pittsburgh in 1852 through rail lines and inclined planes, it began by using portions of the Allegheny Portage RR. Also in 1852, the PRR hired J. Edgar Thomson from the Georgia Railroad to survey and build the line. Thomson served at the Pennsylvania Railroad&#8304;&#769;&#8329;s first engineer and third president responsible for making the PRR a technological innovator until his death in 1874. His work created the layout of the railroad to Pittsburgh as well as the famed Horseshoe Curve in Altoona which opened in 1854. The opening of Horseshoe Curve reduced travel time between Pittsburgh and Philadelphia from a little over three days to 13 hours.   By 1854, all rail lines were completed to Pittsburgh. Lines ran from Philadelphia to Pittsburgh, connecting through Harrisburg. The PRR continued to grow and expand throughout the Nineteenth Century and by the mid-1920s occupied over 10,000 miles of track. The Pennsylvania Railroad merged with the NY Central in 1968 and filed for bankruptcy about two years later. By 1976, assets would be split between Conrail, the Norfolk Southern Railway, and with electrified track east of Harrisburg becoming part of Amtrak.   For a complete history of the Pennsylvania Railroad, please see:   Kobus, Ken, and Jack Consoli. 1996. The Pennsy in the steel city: 150 years of the Pennsylvania Railroad in Pittsburgh. Upper Darby, PA (P.O. Box 389, Upper Darby 19082): Pennsylvania Railroad Technical and Historical Society.</dc:description>
+    <dc:contributor>University of Pittsburgh (depositor)</dc:contributor>
+    <dc:date>1857-1970</dc:date>
+    <dc:type>Collection</dc:type>
+    <dc:type>text</dc:type>
+    <dc:type>Stock certificates</dc:type>
+    <dc:type>Finding aids.</dc:type>
+    <dc:identifier>pitt:US-PPiU-ais201506</dc:identifier>
+    <dc:language>eng</dc:language>
+    <dc:relation>http://digital.library.pitt.edu/cgi-bin/f/findaid/findaid-idx?type=simple;c=ascead;view=text;subview=outline;didno=US-PPiU-ais201506</dc:relation>
+    <dc:coverage>Pennsylvania</dc:coverage>
+    <dc:rights>pdcp_noharvest</dc:rights>
+    <dc:rights>Copyright Not Evaluated. The copyright and related rights status of this Item has not been evaluated. Please refer to the organization that has made the Item available for more information. You are free to use this Item in any way that is permitted by the copyright and related rights legislation that applies to your use.</dc:rights>
+    <dc:rights>http://rightsstatements.org/vocab/CNE/1.0/</dc:rights>
+    <dc:rights>Copyright Not Evaluated. The copyright and related rights status of this Item has not been evaluated. Please refer to the organization that has made the Item available for more information. You are free to use this Item in any way that is permitted by the copyright and related rights legislation that applies to your use.</dc:rights>
+    <dc:rights>http://rightsstatements.org/vocab/CNE/1.0/</dc:rights>
+    <identifier>http://historicpittsburgh.org/islandora/object/pitt%3AUS-PPiU-ais201506</identifier>
+</oai_dc:dc>

--- a/fixtures/schematron/invalid_empty_dc_rights1.xml
+++ b/fixtures/schematron/invalid_empty_dc_rights1.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_dc:dc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:title>Rattlesnake tail</dc:title>
+    <dc:creator>Latrobe, Benjamin Henry, 1764-1820</dc:creator>
+    <dc:subject>Natural history</dc:subject>
+    <dc:subject>Barton, Benjamin Smith, 1766-1815</dc:subject>
+    <dc:subject>Anatomy</dc:subject>
+    <dc:subject>Rattlesnakes</dc:subject>
+    <dc:description>Oversized.</dc:description>
+    <dc:contributor>American Philosophical Society</dc:contributor>
+    <dc:type>StillImage</dc:type>
+    <dc:type>Image</dc:type>
+    <dc:type>Watercolors</dc:type>
+    <dc:type>Ink drawings</dc:type>
+    <dc:identifier>dplapa:APS_graphics_1013</dc:identifier>
+    <dc:identifier>https://diglib.amphilsoc.org/islandora/object/graphics:1013</dc:identifier>
+    <dc:identifier>https://diglib.amphilsoc.org/islandora/object/graphics:1013/datastream/TN/view/</dc:identifier>
+    <dc:source/>
+    <dc:relation>Graphics Collection</dc:relation>
+    <dc:rights/>
+</oai_dc:dc>

--- a/fixtures/schematron/invalid_empty_dc_rights2.xml
+++ b/fixtures/schematron/invalid_empty_dc_rights2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_dc:dc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:title>Rattlesnake tail</dc:title>
+    <dc:creator>Latrobe, Benjamin Henry, 1764-1820</dc:creator>
+    <dc:subject>Natural history</dc:subject>
+    <dc:subject>Barton, Benjamin Smith, 1766-1815</dc:subject>
+    <dc:subject>Anatomy</dc:subject>
+    <dc:subject>Rattlesnakes</dc:subject>
+    <dc:description>Oversized.</dc:description>
+    <dc:contributor>American Philosophical Society</dc:contributor>
+    <dc:type>StillImage</dc:type>
+    <dc:type>Image</dc:type>
+    <dc:type>Watercolors</dc:type>
+    <dc:type>Ink drawings</dc:type>
+    <dc:identifier>dplapa:APS_graphics_1013</dc:identifier>
+    <dc:identifier>https://diglib.amphilsoc.org/islandora/object/graphics:1013</dc:identifier>
+    <dc:identifier>https://diglib.amphilsoc.org/islandora/object/graphics:1013/datastream/TN/view/</dc:identifier>
+    <dc:source/>
+    <dc:relation>Graphics Collection</dc:relation>
+    <dc:rights></dc:rights>
+</oai_dc:dc>

--- a/fixtures/schematron/invalid_empty_dc_title1.xml
+++ b/fixtures/schematron/invalid_empty_dc_title1.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_dc:dc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:title/>
+    <dc:creator>Latrobe, Benjamin Henry, 1764-1820</dc:creator>
+    <dc:subject>Natural history</dc:subject>
+    <dc:subject>Barton, Benjamin Smith, 1766-1815</dc:subject>
+    <dc:subject>Anatomy</dc:subject>
+    <dc:subject>Rattlesnakes</dc:subject>
+    <dc:description>Oversized.</dc:description>
+    <dc:contributor>American Philosophical Society</dc:contributor>
+    <dc:type>StillImage</dc:type>
+    <dc:type>Image</dc:type>
+    <dc:type>Watercolors</dc:type>
+    <dc:type>Ink drawings</dc:type>
+    <dc:identifier>dplapa:APS_graphics_1013</dc:identifier>
+    <dc:identifier>https://diglib.amphilsoc.org/islandora/object/graphics:1013</dc:identifier>
+    <dc:identifier>https://diglib.amphilsoc.org/islandora/object/graphics:1013/datastream/TN/view/</dc:identifier>
+    <dc:source/>
+    <dc:relation>Graphics Collection</dc:relation>
+    <dc:rights>Copyright American Philosophical Society. For reproduction and permission information, see http://www.amphilsoc.org/library/rights.htm</dc:rights>
+</oai_dc:dc>

--- a/fixtures/schematron/invalid_empty_dc_title2.xml
+++ b/fixtures/schematron/invalid_empty_dc_title2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_dc:dc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:title></dc:title>
+    <dc:creator>Latrobe, Benjamin Henry, 1764-1820</dc:creator>
+    <dc:subject>Natural history</dc:subject>
+    <dc:subject>Barton, Benjamin Smith, 1766-1815</dc:subject>
+    <dc:subject>Anatomy</dc:subject>
+    <dc:subject>Rattlesnakes</dc:subject>
+    <dc:description>Oversized.</dc:description>
+    <dc:contributor>American Philosophical Society</dc:contributor>
+    <dc:type>StillImage</dc:type>
+    <dc:type>Image</dc:type>
+    <dc:type>Watercolors</dc:type>
+    <dc:type>Ink drawings</dc:type>
+    <dc:identifier>dplapa:APS_graphics_1013</dc:identifier>
+    <dc:identifier>https://diglib.amphilsoc.org/islandora/object/graphics:1013</dc:identifier>
+    <dc:identifier>https://diglib.amphilsoc.org/islandora/object/graphics:1013/datastream/TN/view/</dc:identifier>
+    <dc:source/>
+    <dc:relation>Graphics Collection</dc:relation>
+    <dc:rights>Copyright American Philosophical Society. For reproduction and permission information, see http://www.amphilsoc.org/library/rights.htm</dc:rights>
+</oai_dc:dc>

--- a/fixtures/schematron/invalid_missing_dc_multiple.xml
+++ b/fixtures/schematron/invalid_missing_dc_multiple.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_dc:dc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:creator>Latrobe, Benjamin Henry, 1764-1820</dc:creator>
+    <dc:subject>Natural history</dc:subject>
+    <dc:subject>Barton, Benjamin Smith, 1766-1815</dc:subject>
+    <dc:subject>Anatomy</dc:subject>
+    <dc:subject>Rattlesnakes</dc:subject>
+    <dc:description>Oversized.</dc:description>
+    <dc:contributor>American Philosophical Society</dc:contributor>
+    <dc:type>StillImage</dc:type>
+    <dc:type>Image</dc:type>
+    <dc:type>Watercolors</dc:type>
+    <dc:type>Ink drawings</dc:type>
+    <dc:identifier>dplapa:APS_graphics_1013</dc:identifier>
+    <dc:identifier>https://diglib.amphilsoc.org/islandora/object/graphics:1013</dc:identifier>
+    <dc:identifier>https://diglib.amphilsoc.org/islandora/object/graphics:1013/datastream/TN/view/</dc:identifier>
+    <dc:source/>
+    <dc:relation>Graphics Collection</dc:relation>
+</oai_dc:dc>

--- a/fixtures/schematron/invalid_missing_dc_rights.xml
+++ b/fixtures/schematron/invalid_missing_dc_rights.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_dc:dc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:title>Rattlesnake tail</dc:title>
+    <dc:creator>Latrobe, Benjamin Henry, 1764-1820</dc:creator>
+    <dc:subject>Natural history</dc:subject>
+    <dc:subject>Barton, Benjamin Smith, 1766-1815</dc:subject>
+    <dc:subject>Anatomy</dc:subject>
+    <dc:subject>Rattlesnakes</dc:subject>
+    <dc:description>Oversized.</dc:description>
+    <dc:contributor>American Philosophical Society</dc:contributor>
+    <dc:type>StillImage</dc:type>
+    <dc:type>Image</dc:type>
+    <dc:type>Watercolors</dc:type>
+    <dc:type>Ink drawings</dc:type>
+    <dc:identifier>dplapa:APS_graphics_1013</dc:identifier>
+    <dc:identifier>https://diglib.amphilsoc.org/islandora/object/graphics:1013</dc:identifier>
+    <dc:identifier>https://diglib.amphilsoc.org/islandora/object/graphics:1013/datastream/TN/view/</dc:identifier>
+    <dc:source/>
+    <dc:relation>Graphics Collection</dc:relation>
+</oai_dc:dc>

--- a/fixtures/schematron/invalid_missing_dc_title.xml
+++ b/fixtures/schematron/invalid_missing_dc_title.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_dc:dc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:creator>Latrobe, Benjamin Henry, 1764-1820</dc:creator>
+    <dc:subject>Natural history</dc:subject>
+    <dc:subject>Barton, Benjamin Smith, 1766-1815</dc:subject>
+    <dc:subject>Anatomy</dc:subject>
+    <dc:subject>Rattlesnakes</dc:subject>
+    <dc:description>Oversized.</dc:description>
+    <dc:contributor>American Philosophical Society</dc:contributor>
+    <dc:type>StillImage</dc:type>
+    <dc:type>Image</dc:type>
+    <dc:type>Watercolors</dc:type>
+    <dc:type>Ink drawings</dc:type>
+    <dc:identifier>dplapa:APS_graphics_1013</dc:identifier>
+    <dc:identifier>https://diglib.amphilsoc.org/islandora/object/graphics:1013</dc:identifier>
+    <dc:identifier>https://diglib.amphilsoc.org/islandora/object/graphics:1013/datastream/TN/view/</dc:identifier>
+    <dc:source/>
+    <dc:relation>Graphics Collection</dc:relation>
+    <dc:rights>Copyright American Philosophical Society. For reproduction and permission information, see http://www.amphilsoc.org/library/rights.htm</dc:rights>
+</oai_dc:dc>

--- a/fixtures/schematron/valid_dc.xml
+++ b/fixtures/schematron/valid_dc.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_dc:dc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:title>Rattlesnake tail</dc:title>
+    <dc:creator>Latrobe, Benjamin Henry, 1764-1820</dc:creator>
+    <dc:subject>Natural history</dc:subject>
+    <dc:subject>Barton, Benjamin Smith, 1766-1815</dc:subject>
+    <dc:subject>Anatomy</dc:subject>
+    <dc:subject>Rattlesnakes</dc:subject>
+    <dc:description>Oversized.</dc:description>
+    <dc:contributor>American Philosophical Society</dc:contributor>
+    <dc:type>StillImage</dc:type>
+    <dc:type>Image</dc:type>
+    <dc:type>Watercolors</dc:type>
+    <dc:type>Ink drawings</dc:type>
+    <dc:identifier>dplapa:APS_graphics_1013</dc:identifier>
+    <dc:identifier>https://diglib.amphilsoc.org/islandora/object/graphics:1013</dc:identifier>
+    <dc:identifier>https://diglib.amphilsoc.org/islandora/object/graphics:1013/datastream/TN/view/</dc:identifier>
+    <dc:source/>
+    <dc:relation>Graphics Collection</dc:relation>
+    <dc:rights>Copyright American Philosophical Society. For reproduction and permission information, see http://www.amphilsoc.org/library/rights.htm</dc:rights>
+</oai_dc:dc>

--- a/tests/schematron/dcingest_reqd_fields.xspec
+++ b/tests/schematron/dcingest_reqd_fields.xspec
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+  schematron="../../validations/dcingest_reqd_fields.sch">
+  <x:scenario label="RequiredElementsPattern">
+    <x:scenario label="valid: dc:title">
+      <x:context href="../../fixtures/schematron/valid_dc.xml"/>
+      <x:expect-valid/>
+    </x:scenario>
+    <x:scenario label="not valid: missing title">
+      <x:context href="../../fixtures/schematron/invalid_missing_dc_title.xml"/>
+      <x:expect-assert id="Required1"/>
+    </x:scenario>
+    <x:scenario label="valid: dc:rights>">
+      <x:context href="../../fixtures/schematron/valid_dc.xml"/>
+      <x:expect-valid/>
+    </x:scenario>
+    <x:scenario label="not valid: missing rights">
+      <x:context href="../../fixtures/schematron/invalid_missing_dc_rights.xml"/>
+      <x:expect-assert id="Required2"/>
+    </x:scenario>
+    <x:scenario label="not valid: missing multiple">
+      <x:context href="../../fixtures/schematron/invalid_missing_dc_multiple.xml"/>
+      <x:expect-assert id="Required1"/>
+      <x:expect-assert id="Required2"/>
+    </x:scenario>
+  </x:scenario>
+  <x:scenario label="TitleElementPattern">
+    <x:scenario label="valid">
+      <x:context href="../../fixtures/schematron/valid_dc.xml"/>
+      <x:expect-valid/>
+    </x:scenario>
+    <x:scenario label="not valid">
+      <x:scenario label="not valid: empty title 1">
+        <x:context href="../../fixtures/schematron/invalid_empty_dc_title1.xml"/>
+        <x:expect-assert id="Title1"/>
+      </x:scenario>
+      <x:scenario label="not valid: empty title 2">
+        <x:context href="../../fixtures/schematron/invalid_empty_dc_title2.xml"/>
+        <x:expect-assert id="Title1"/>
+      </x:scenario>
+    </x:scenario>
+  </x:scenario>
+  <x:scenario label="RightsElementPattern">
+    <x:scenario label="valid">
+      <x:context href="../../fixtures/schematron/valid_dc.xml"/>
+      <x:expect-valid/>
+    </x:scenario>
+    <x:scenario label="not valid">
+      <x:scenario label="not valid: empty rights 1">
+        <x:context href="../../fixtures/schematron/invalid_empty_dc_rights1.xml"/>
+        <x:expect-assert id="Rights1"/>
+      </x:scenario>
+      <x:scenario label="not valid: empty rights 2">
+        <x:context href="../../fixtures/schematron/invalid_empty_dc_rights2.xml"/>
+        <x:expect-assert id="Rights1"/>
+      </x:scenario>
+    </x:scenario>
+  </x:scenario>
+  <x:scenario label="RelNoHarvest">
+    <x:scenario label="valid">
+      <x:context href="../../fixtures/schematron/valid_dc.xml"/>
+      <x:expect-valid/>
+    </x:scenario>
+    <x:scenario label="not valid">
+      <x:context href="../../fixtures/schematron/invalid_RelNoHarvest.xml"/>
+      <x:expect-assert id="RelNoHarvest1"/>
+    </x:scenario>
+  </x:scenario>
+  <x:scenario label="RightsNoHarvest">
+    <x:scenario label="valid">
+      <x:context href="../../fixtures/schematron/valid_dc.xml"/>
+      <x:expect-valid/>
+    </x:scenario>
+    <x:scenario label="not valid">
+      <x:context href="../../fixtures/schematron/invalid_RightsNoHarvest.xml"/>
+      <x:expect-assert id="Rights1NoHarvest1"/>
+    </x:scenario>
+  </x:scenario>
+</x:description>

--- a/validations/dcingest_reqd_fields.sch
+++ b/validations/dcingest_reqd_fields.sch
@@ -12,31 +12,31 @@
     <pattern id="RequiredElementsPattern">
       <title>DPLAH fields required</title>
         <rule context="oai_dc:dc">
-          <assert test="dc:title">There must be a title</assert>
-          <assert test="dc:rights">There must be a rights statement</assert>
+          <assert test="dc:title" id="Required1" role="error">There must be a title</assert>
+          <assert test="dc:rights" id="Required2" role="error">There must be a rights statement</assert>
         </rule>
     </pattern>
     <pattern id="TitleElementPattern">
       <title>Required fields must contain text.</title>
         <rule context="oai_dc:dc/dc:title">
-          <assert test="normalize-space(.)">The title property must contain text</assert>
+          <assert test="normalize-space(.)" id="Title1" role="error">The title property must contain text</assert>
         </rule>
       </pattern>
       <pattern id="RightsElementPattern">
         <rule context="oai_dc:dc/dc:rights">
-          <assert test="normalize-space(.)">The rights property must contain text</assert>
+          <assert test="normalize-space(.)" id="Rights1" role="error">The rights property must contain text</assert>
         </rule>
       </pattern>
       <pattern id="RelNoHarvest">
           <title>Additional Metadata Requirements</title>
           <rule context="oai_dc:dc/dc:relation">
-              <assert test="normalize-space(.) != 'pdcp_noharvest'" id="NoHarvest1" role="error">The relation element must not contain stopword</assert>
+              <assert test="normalize-space(.) != 'pdcp_noharvest'" id="RelNoHarvest1" role="error">The relation element must not contain stopword</assert>
           </rule>
       </pattern>
       <pattern id="RightsNoHarvest">
           <title>Additional Metadata Requirements</title>
           <rule context="oai_dc:dc/dc:rights">
-              <assert test="normalize-space(.) != 'pdcp_noharvest'" id="NoHarvest1" role="error">The rights element must not contain stopword</assert>
+              <assert test="normalize-space(.) != 'pdcp_noharvest'" id="RightsNoHarvest1" role="error">The rights element must not contain stopword</assert>
           </rule>
       </pattern>
 </schema>


### PR DESCRIPTION
What this PR does:
- updates dcingest_reqd_fields.sch to add assert identifiers
- adds dcingest_reqd_fields.xspec test
- adds associated fixtures for dcingest_reqd_fields.xspec