### PR TITLE
Add hp test xslt fix

### DIFF
--- a/.circleci/tests.sh
+++ b/.circleci/tests.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
-set -e
 
 for xspectest in $(ls tests/xslt/*.xspec); do \
 docker run xspec "$xspectest" &> .circleci/result.log;
     if grep -q ".*failed:\s[1-9]" .circleci/result.log || grep -q -E "\*+\sError\s(running|compiling)\sthe\stest\ssuite" .circleci/result.log;
-        then
-            echo "FAILED: $xspectest";
-            echo "---------- result.log";
-            cat .circleci/result.log;
-            echo "----------";
-            exit 1;
-        else echo "OK: $xspectest";
+      then
+          echo "FAILED: $xspectest";
+          echo "---------- result.log";
+          cat .circleci/result.log;
+          echo "----------";
+          exit 1;
+      else echo "OK: $xspectest";
     fi
 done
 

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+
+[requires]
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,20 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "7e7ef69da7248742e869378f8421880cf8f0017f96d94d086813baa518a65489"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {},
+    "develop": {}
+}

--- a/fixtures/historicpitt_test.oaidc_2.xml
+++ b/fixtures/historicpitt_test.oaidc_2.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<documents>
+  <record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.openarchives.org/OAI/2.0/">
+    <header>
+      <identifier>oai:histpitt.library.pitt.edu:pitt_715.3420584.CP</identifier>
+      <datestamp>2018-07-16T21:21:19Z</datestamp>
+      <setSpec>pitt_collection.72</setSpec>
+    </header>
+    <metadata>
+      <oai_dc:dc
+        xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+        xmlns:dc="http://purl.org/dc/elements/1.1/">
+        <dc:title>Overbrook School</dc:title>
+        <dc:creator>Pittsburgh City Photographer</dc:creator>
+        <dc:subject>Overbrook Elementary School (Pittsburgh, Pa.)</dc:subject>
+        <dc:description>A view of the Overbrook Elementary School. The school closed in
+          2002.</dc:description>
+        <dc:contributor>University of Pittsburgh (depositor)</dc:contributor>
+        <dc:date>1934-06-20</dc:date>
+        <dc:type>StillImage</dc:type>
+        <dc:type>photograph</dc:type>
+        <dc:identifier>pitt:715.3420584.CP</dc:identifier>
+        <dc:relation>Pittsburgh City Photographer Collection, 1901-2002</dc:relation>
+        <dc:coverage>Overbrook</dc:coverage>
+        <dc:rights>No Copyright - United States. The organization that has made the Item available
+          believes that the Item is in the Public Domain under the laws of the United States, but a
+          determination was not made as to its copyright status under the copyright laws of other
+          countries. The Item may not be in the Public Domain under the laws of other countries.
+          Please refer to the organization that has made the Item available for more
+          information.</dc:rights>
+        <dc:rights>http://rightsstatements.org/vocab/NoC-US/1.0/</dc:rights>
+        <dc:identifier.thumbnail>http://historicpittsburgh.org/islandora/object/pitt%3A715.3420584.CP/datastream/TN/view/Overbrook%20School.jpg</dc:identifier.thumbnail>
+        <identifier>http://historicpittsburgh.org/islandora/object/pitt%3A715.3420584.CP</identifier>
+        <dc:source>This is a Source</dc:source>
+        <dc:publisher>This is a Publisher</dc:publisher>
+        <dc:language>English</dc:language>
+      </oai_dc:dc>
+    </metadata>
+  </record>
+</documents>

--- a/tests/xslt/historicpitt.xspec
+++ b/tests/xslt/historicpitt.xspec
@@ -1,0 +1,918 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    xmlns:dpla="http://dp.la/about/map/"
+    xmlns:edm="http://www.europeana.eu/schemas/edm/"
+    xmlns:oclcdc="http://worldcat.org/xmlschemas/oclcdc-1.0/"
+    xmlns:oclcterms="http://purl.org/oclc/terms/"
+    xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+    xmlns:oai_dc='http://www.openarchives.org/OAI/2.0/oai_dc/'
+    xmlns:oclc="http://purl.org/oclc/terms/"
+    xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/"
+    xmlns:schema="http://schema.org"
+    xmlns:svcs="http://rdfs.org/sioc/services"
+    stylesheet="../../transforms/historicpitt.xsl">
+
+    <!-- Drop deleted records -->
+    <!-- This does not work in historicpitt.xsl as currently implemented.
+    Restore test when this functionality is fixed in the XSLT
+
+    <x:scenario label="OAI Deleted Records are Skipped">
+        <x:context>
+            <oai:record>
+                <oai:header status="deleted">
+                    <identifier>oai:record-that-should-be-ignored</identifier>
+                    <setSpec>TEST1</setSpec>
+                </oai:header>
+                <metadata>
+                    <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
+                        http://www.openarchives.org/OAI/2.0/oai_dc.xsd"
+                        xmlns="http://purl.org/dc/elements/1.1/"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                        <title>Champaign County, Illinois</title>
+                        <creator>United States. Agricultureal Adjustment Administration</creator>
+                        <identifier>record-that-should-be-ignored</identifier>
+                    </oai_dc:dc>
+                </metadata>
+            </oai:record>
+            <oai:record>
+                <oai:header>
+                    <identifier>oai:record-that-should-be-kept</identifier>
+                    <setSpec>TEST2</setSpec>
+                </oai:header>
+                <metadata>
+                    <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
+                        http://www.openarchives.org/OAI/2.0/oai_dc.xsd"
+                        xmlns="http://purl.org/dc/elements/1.1/"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                        <title>Champaign County, Illinois</title>
+                        <creator>United States. Agricultureal Adjustment Administration</creator>
+                        <identifier>record-that-should-be-kept</identifier>
+                    </oai_dc:dc>
+                </metadata>
+            </oai:record>
+        </x:context>
+        <x:expect label="1 record remains" test="count(oai_dc:dc) = 1"/>
+        <x:expect label="OAI Record Identifier of 1 Record is record-that-should-be-kept"
+            test="oai_dc:dc/dcterms:identifier = 'record-that-should-be-kept'" />
+    </x:scenario>
+    -->
+
+    <!-- Filtered Identifiers -->
+    <!-- This does not work in historicpitt.xsl as currently implemented.
+    Restore test when this functionality is enabled in the XSLT
+
+    <x:scenario label="Records with Filtered Identifiers are Skipped">
+      <x:context>
+        <oai:record>
+          <oai:header>
+            <identifier>oai:test-filter-record-1</identifier>
+            <setSpec>TEST1</setSpec>
+          </oai:header>
+          <metadata>
+            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
+                http://www.openarchives.org/OAI/2.0/oai_dc.xsd"
+                xmlns="http://purl.org/dc/elements/1.1/"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+              <title>Champaign County, Illinois</title>
+              <creator>United States. Agricultureal Adjustment Administration</creator>
+              <identifier>test-filter-record-1</identifier>
+            </oai_dc:dc>
+          </metadata>
+        </oai:record>
+        <oai:record>
+          <oai:header>
+            <identifier>oai:record-that-should-be-kept</identifier>
+            <setSpec>TEST2</setSpec>
+          </oai:header>
+          <metadata>
+            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
+                      http://www.openarchives.org/OAI/2.0/oai_dc.xsd"
+                      xmlns="http://purl.org/dc/elements/1.1/"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+              <title>Champaign County, Illinois</title>
+              <creator>United States. Agricultureal Adjustment Administration</creator>
+              <identifier>record-that-should-be-kept</identifier>
+            </oai_dc:dc>
+          </metadata>
+        </oai:record>
+        <oai:record>
+          <oai:header>
+            <identifier>oai:test-filter-record-2</identifier>
+            <setSpec>TEST3</setSpec>
+          </oai:header>
+          <metadata>
+            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
+                http://www.openarchives.org/OAI/2.0/oai_dc.xsd"
+                xmlns="http://purl.org/dc/elements/1.1/"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+              <title>Champaign County, Illinois</title>
+              <creator>United States. Agricultureal Adjustment Administration</creator>
+              <identifier>test-filter-record-2</identifier>
+            </oai_dc:dc>
+          </metadata>
+        </oai:record>
+      </x:context>
+      <x:expect label="1 record remains" test="count(oai_dc:dc) = 1"/>
+      <x:expect label="Record Identifier of Record is not one of filtered records"
+        test="oai_dc:dc/dcterms:identifier != 'test-filter-record-1'" />
+      <x:expect label="Record Identifier of Record is not one of filtered records"
+        test="oai_dc:dc/dcterms:identifier != 'test-filter-record-2'" />
+    </x:scenario>
+  -->
+
+    <!-- OAI Header SetSpec -->
+
+    <x:scenario label="SetSpec is looked up and matched to collection name">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="SetSpec matches collection in lookup.xsl"
+          test="oai_dc:dc/dcterms:isPartOf = 'Pittsburgh City Photographer Collection'"/>
+    </x:scenario>
+
+    <!-- Title -->
+
+    <x:scenario label="dc:title processing">
+        <x:context>
+            <oai:record>
+                <metadata>
+                    <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd"
+                      xmlns="http://purl.org/dc/elements/1.1/"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                        <title>First Title</title>
+                        <title>Second Title</title>
+                    </oai_dc:dc>
+                </metadata>
+            </oai:record>
+        </x:context>
+        <x:expect label="1st dc.title is transformed to dcterms:title"
+          test="oai_dc:dc/dcterms:title = 'First Title'"/>
+        <x:expect label="2nd dc:title is transformed to dcterms:alternative"
+          test="oai_dc:dc/dcterms:alternative = 'Second Title'"/>
+    </x:scenario>
+
+    <!-- Contributor and Contributing Institution -->
+
+    <x:scenario label="dc:contributor processing">
+        <x:context>
+            <oai:record>
+                <metadata>
+                    <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd"
+                      xmlns="http://purl.org/dc/elements/1.1/"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                        <contributor>Carnegie, Andrew</contributor>
+                        <contributor>University of Pittsburgh (depositor)</contributor>
+                    </oai_dc:dc>
+                </metadata>
+            </oai:record>
+        </x:context>
+        <x:expect label="generate edm:dataProvider from dc:contributor when (depositor) is present"
+          test="oai_dc:dc/edm:dataProvider = 'University of Pittsburgh'"/>
+        <x:expect label="other dc:contributor transforms to dcterms:contributor"
+          test="oai_dc:dc/dcterms:contributor = 'Carnegie, Andrew'"/>
+    </x:scenario>
+
+    <!-- Alternative titles (QDC) -->
+
+    <x:scenario label="dcterms:alternative is transformed to dcterms:alternative">
+        <x:scenario label="titles other">
+            <x:context>
+                <oai:record>
+                    <metadata>
+                        <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/"
+                            xmlns:dcterms="http://purl.org/dc/terms/"
+                            xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/"
+                            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                            xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+                            <dcterms:alternative>Hello Alternate Title</dcterms:alternative>
+                        </oai_qdc:qualifieddc>>
+                    </metadata>
+                </oai:record>
+            </x:context>
+            <x:expect label="dcterms:alternative is transformed to dcterms:alternative"
+              test="oai_dc:dc/dcterms:alternative = 'Hello Alternate Title'"/>
+        </x:scenario>
+    </x:scenario>
+
+    <!-- Type remediation -->
+
+    <x:scenario label="dc:type values are matched and remediated for known strings">
+        <x:scenario label="Text Type Remediation">
+            <x:scenario label="Text Type Remediation: Starts with lowercase text">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>textual kittens</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Text'" test="oai_dc:dc/dcterms:type = 'Text'" />
+            </x:scenario>
+            <x:scenario label="Text Type Remediation: Starts with mixed case text">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>TEXTresource</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Text'" test="oai_dc:dc/dcterms:type = 'Text'" />
+            </x:scenario>
+            <x:scenario label="Text Type Remediation: text exact lowercase">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>text</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Text'" test="oai_dc:dc/dcterms:type = 'Text'" />
+            </x:scenario>
+            <x:scenario label="Text Type Remediation: text exact uppercase">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>TEXT</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Text'" test="oai_dc:dc/dcterms:type = 'Text'" />
+            </x:scenario>
+            <x:scenario label="Text Type Remediation: ends with text becomes format">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>hello-text</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:format is original value" test="oai_dc:dc/dcterms:format = 'hello-text'" />
+                <x:expect label="Output record dcterms:type does not exist" test="not(oai_dc:dc/dcterms:type)" />
+            </x:scenario>
+        </x:scenario>
+        <x:scenario label="Image Type Remediation">
+            <x:scenario label="Image Type Remediation: Starts with lowercase image">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>image of kittens</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Image'" test="oai_dc:dc/dcterms:type = 'Image'" />
+            </x:scenario>
+            <x:scenario label="Image Type Remediation: Starts with mixed case Image">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>ImAgEresource</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Image'" test="oai_dc:dc/dcterms:type = 'Image'" />
+            </x:scenario>
+            <x:scenario label="Image Image Remediation: image exact lowercase">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>image</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Image'" test="oai_dc:dc/dcterms:type = 'Image'" />
+            </x:scenario>
+            <x:scenario label="Image Type Remediation: image exact uppercase">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>IMAGE</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Image'" test="oai_dc:dc/dcterms:type = 'Image'" />
+            </x:scenario>
+            <x:scenario label="Image Type Remediation: ends with image becomes format">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>hello-image</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:format is original value" test="oai_dc:dc/dcterms:format = 'hello-image'" />
+                <x:expect label="Output record dcterms:type does not exist" test="not(oai_dc:dc/dcterms:type)" />
+            </x:scenario>
+        </x:scenario>
+        <x:scenario label="Moving Image Type Remediation">
+            <x:scenario label="Moving Image Type Remediation: Starts with lowercase, no spaces movingimage">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>movingimagekittens</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Moving Image'" test="oai_dc:dc/dcterms:type = 'Moving Image'" />
+            </x:scenario>
+            <x:scenario label="Moving Image Type Remediation: Starts with lowercase, single-spaced moving image">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>moving imagekittens</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Moving Image'" test="oai_dc:dc/dcterms:type = 'Moving Image'" />
+            </x:scenario>
+            <x:scenario label="Moving Image Type Remediation: Starts with mixed case moving image">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>MOVING ImAgEresource</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Moving Image'" test="oai_dc:dc/dcterms:type = 'Moving Image'" />
+            </x:scenario>
+            <x:scenario label="Moving Image Remediation: Moving Image exact lowercase">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>moving image</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Moving Image'" test="oai_dc:dc/dcterms:type = 'Moving Image'" />
+            </x:scenario>
+            <x:scenario label="Moving Image Type Remediation: Moving Image exact uppercase">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>MOVING IMAGE</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Moving Image'" test="oai_dc:dc/dcterms:type = 'Moving Image'" />
+            </x:scenario>
+            <x:scenario label="Moving Image Type Remediation: ends with Moving Image becomes format">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>hello-moving-image</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:format is original value" test="oai_dc:dc/dcterms:format = 'hello-moving-image'" />
+                <x:expect label="Output record dcterms:type does not exist" test="not(oai_dc:dc/dcterms:type)" />
+            </x:scenario>
+        </x:scenario>
+        <x:scenario label="Sound Type Remediation">
+            <x:scenario label="Sound Type Remediation: Starts with lowercase sound">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>sound of kittens</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Sound'" test="oai_dc:dc/dcterms:type = 'Sound'" />
+            </x:scenario>
+            <x:scenario label="Sound Type Remediation: Starts with mixed case sound">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>SoUnDresource</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Sound'" test="oai_dc:dc/dcterms:type = 'Sound'" />
+            </x:scenario>
+            <x:scenario label="Sound Type Remediation: Sound exact lowercase">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>sound</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Sound'" test="oai_dc:dc/dcterms:type = 'Sound'" />
+            </x:scenario>
+            <x:scenario label="Sound Type Remediation: Sound exact uppercase">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>SOUND</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Sound'" test="oai_dc:dc/dcterms:type = 'Sound'" />
+            </x:scenario>
+            <x:scenario label="Sound Type Remediation: ends with sound becomes format">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>hello-sound</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:format is original value" test="oai_dc:dc/dcterms:format = 'hello-sound'" />
+                <x:expect label="Output record dcterms:type does not exist" test="not(oai_dc:dc/dcterms:type)" />
+            </x:scenario>
+        </x:scenario>
+        <x:scenario label="Physical Object Type Remediation">
+            <x:scenario label="Physical Object Type Remediation: Starts with lowercase, no spaces physicalobject">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>physicalobjectkittens</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Physical Object'" test="oai_dc:dc/dcterms:type = 'Physical Object'" />
+            </x:scenario>
+            <x:scenario label="Physical Object Type Remediation: Starts with lowercase, single-spaced Physical Object">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>physical object kittens</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Physical Object'" test="oai_dc:dc/dcterms:type = 'Physical Object'" />
+            </x:scenario>
+            <x:scenario label="Physical Object Type Remediation: Starts with mixed case Physical Object">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>PHYSical Objectresource</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Physical Object'" test="oai_dc:dc/dcterms:type = 'Physical Object'" />
+            </x:scenario>
+            <x:scenario label="Physical Object Remediation: Physical Object exact lowercase">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>physical object</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Physical Object'" test="oai_dc:dc/dcterms:type = 'Physical Object'" />
+            </x:scenario>
+            <x:scenario label="Physical Object Type Remediation: Physical Object exact uppercase">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>PHYSICAL OBJECT</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Physical Object'" test="oai_dc:dc/dcterms:type = 'Physical Object'" />
+            </x:scenario>
+            <x:scenario label="Physical Object Type Remediation: ends with Physical Object becomes format">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>hello-physical-object</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:format is original value" test="oai_dc:dc/dcterms:format = 'hello-physical-object'" />
+                <x:expect label="Output record dcterms:type does not exist" test="not(oai_dc:dc/dcterms:type)" />
+            </x:scenario>
+        </x:scenario>
+        <x:scenario label="Interactive Resource Type Remediation">
+            <x:scenario label="Interactive Resource Type Remediation: Starts with lowercase, no spaces interactiveresource">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>interactiveresourcepuppies</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Interactive Resource'" test="oai_dc:dc/dcterms:type = 'Interactive Resource'" />
+            </x:scenario>
+            <x:scenario label="Interactive Resource Type Remediation: Starts with lowercase, single-spaced Interactive Resource">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>interactive resource kittens</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Interactive Resource'" test="oai_dc:dc/dcterms:type = 'Interactive Resource'" />
+            </x:scenario>
+            <x:scenario label="Interactive Resource Type Remediation: Starts with mixed case Interactive Resource">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>InterActive Resource resources</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Interactive Resource'" test="oai_dc:dc/dcterms:type = 'Interactive Resource'" />
+            </x:scenario>
+            <x:scenario label="Interactive Resource Remediation: Interactive Resource exact lowercase">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>interactive resource</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Interactive Resource'" test="oai_dc:dc/dcterms:type = 'Interactive Resource'" />
+            </x:scenario>
+            <x:scenario label="Interactive Resource Type Remediation: Interactive Resource exact uppercase">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>INTERACTIVE RESOURCE</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:type is 'Interactive Resource'" test="oai_dc:dc/dcterms:type = 'Interactive Resource'" />
+            </x:scenario>
+            <x:scenario label="Interactive Resource Type Remediation: ends with Interactive Resource becomes format">
+                <x:context>
+                    <oai:record>
+                        <metadata>
+                            <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                                <type>hello-interactive-resource</type>
+                                <identifier>record-that-should-be-kept</identifier>
+                            </oai_dc:dc>
+                        </metadata>
+                    </oai:record>
+                </x:context>
+                <x:expect label="Output record dcterms:format is original value" test="oai_dc:dc/dcterms:format = 'hello-interactive-resource'" />
+                <x:expect label="Output record dcterms:type does not exist" test="not(oai_dc:dc/dcterms:type)" />
+            </x:scenario>
+        </x:scenario>
+    </x:scenario>
+
+    <!-- Note to add test for splitting Type by delimiter when this is enabled in the stylesheet-->
+
+    <!-- Creator -->
+
+    <x:scenario label="dc:creator is transformed to dcterms:creator">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="dc:creator is transformed to dcterms:creator" test="oai_dc:dc/dcterms:creator = 'Pittsburgh City Photographer'"/>
+    </x:scenario>
+
+    <!-- Source -->
+
+    <x:scenario label="dc:source is transformed to dcterms:source">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="dc:source is transformed to dcterms:source" test="oai_dc:dc/dcterms:source = 'This is a Source'"/>
+    </x:scenario>
+
+    <!-- Publisher -->
+
+    <x:scenario label="dc:publisher is transformed to dcterms:publisher">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="dc:publisher is transformed to dcterms:publisher" test="oai_dc:dc/dcterms:publisher = 'This is a Publisher'"/>
+    </x:scenario>
+
+    <!-- Description -->
+
+    <x:scenario label="dc:description is transformed to dcterms:description">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="dc:description is transformed to dcterms:description" test="oai_dc:dc/dcterms:description = 'A view of the Overbrook Elementary School. The school closed in 2002.'"/>
+    </x:scenario>
+
+    <!-- Place (Simple DC) -->
+
+    <x:scenario label="dc:coverage is tranformed to dcterms:spatial">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="dc:coverage is transformed to dcterms:spatial" test="oai_dc:dc/dcterms:spatial = 'Overbrook'" />
+    </x:scenario>
+
+    <!-- Place (QDC) -->
+
+    <x:scenario label="dcterms:spatial is transformed to dcterms:spatial">
+        <x:context>
+            <oai:record>
+                <metadata>
+                    <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/"
+                        xmlns:dcterms="http://purl.org/dc/terms/"
+                        xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+                        <dcterms:spatial>Place 2</dcterms:spatial>
+                    </oai_qdc:qualifieddc>>
+                </metadata>
+            </oai:record>
+        </x:context>
+        <x:expect label="dcterms:spatial is transformed to dcterms:spatial" test="oai_dc:dc/dcterms:spatial = 'Place 2'"/>
+    </x:scenario>
+
+    <!-- Temporal coverage (QDC) -->
+
+    <x:scenario label="dcterms:temporal is transformed to dcterms:temporal">
+        <x:context>
+            <oai:record>
+                <metadata>
+                    <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/"
+                        xmlns:dcterms="http://purl.org/dc/terms/"
+                        xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+                        <dcterms:temporal>Hello Temporal Coverage</dcterms:temporal>
+                    </oai_qdc:qualifieddc>>
+                </metadata>
+            </oai:record>
+        </x:context>
+        <x:expect label="dcterms:temporal is transformed to dcterms:temporal" test="oai_dc:dc/dcterms:temporal = 'Hello Temporal Coverage'"/>
+    </x:scenario>
+
+    <!-- Extent (QDC) -->
+
+    <x:scenario label="dcterms:extent is transformed to dcterms:extent">
+        <x:context>
+            <oai:record>
+                <metadata>
+                    <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/"
+                        xmlns:dcterms="http://purl.org/dc/terms/"
+                        xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+                        <dcterms:extent>300 pages</dcterms:extent>
+                    </oai_qdc:qualifieddc>>
+                </metadata>
+            </oai:record>
+        </x:context>
+        <x:expect label="dcterms:extent is transformed to dcterms:extent" test="oai_dc:dc/dcterms:extent = '300 pages'"/>
+    </x:scenario>
+
+    <!-- Date -->
+
+    <x:scenario label="dc:date is transformed to dcterms:date">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="dc:date is transformed to dcterms:date" test="oai_dc:dc/dcterms:date = '1934-06-20'"/>
+    </x:scenario>
+
+    <!-- Subject Mapping -->
+
+    <x:scenario label="dc:subject is transformed to dcterms:subject">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="dc:subject is transformed to dcterms:subject" test="oai_dc:dc/dcterms:subject = 'Overbrook Elementary School (Pittsburgh, Pa.)'"/>
+    </x:scenario>
+
+    <!-- Subject splitting by delimiter -->
+    <!-- Note to add an additional test for space padding when enabled in the stylesheet -->
+
+    <x:scenario label="Split subject by delimiter">
+        <x:context>
+            <oai:record>
+                <metadata>
+                    <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                        <subject>Schools; Education</subject>
+                    </oai_dc:dc>
+                </metadata>
+            </oai:record>
+        </x:context>
+        <x:expect label="subject is split into separate fields">
+                <oai_dc:dc xmlns:padig="http://padigitial.org/ns/"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xmlns:dc="http://purl.org/dc/elements/1.1/"
+                    xmlns:dcterms="http://purl.org/dc/terms/"
+                    xmlns:dpla="http://dp.la/about/map/"
+                    xmlns:edm="http://www.europeana.eu/schemas/edm/"
+                    xmlns:oclcdc="http://worldcat.org/xmlschemas/oclcdc-1.0/"
+                    xmlns:oclcterms="http://purl.org/oclc/terms/"
+                    xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+                    xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                    xmlns:oclc="http://purl.org/oclc/terms/"
+                    xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/"
+                    xmlns:schema="http://schema.org"
+                    xmlns:svcs="http://rdfs.org/sioc/services">
+                    <dcterms:subject>Schools</dcterms:subject>
+                    <dcterms:subject>Education</dcterms:subject>
+                    <dpla:intermediateProvider>Historic Pittsburgh</dpla:intermediateProvider>
+                    <edm:provider>PA Digital</edm:provider>
+                </oai_dc:dc>
+        </x:expect>
+    </x:scenario>
+
+    <!-- Language Mapping -->
+
+    <x:scenario label="dc:language is transformed to dcterms:language">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="dc:language is transformed to dcterms:language" test="oai_dc:dc/dcterms:language = 'English'"/>
+    </x:scenario>
+
+    <!-- Note to add test for language splitting by delimiter when it is enabled in the stylesheet -->
+
+    <!-- Relation -->
+
+    <x:scenario label="dc:relation is transformed to dcterms:relation">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="dc:relation is transformed to dcterms:relation" test="oai_dc:dc/dcterms:relation = 'Pittsburgh City Photographer Collection, 1901-2002'"/>
+    </x:scenario>
+
+    <!-- Replaced by (QDC) -->
+
+    <x:scenario label="dcterms:isReplacedBy is transformed to dcterms:isReplacedBy">
+        <x:context>
+            <oai:record>
+                <metadata>
+                    <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/"
+                        xmlns:dcterms="http://purl.org/dc/terms/"
+                        xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+                        <dcterms:isReplacedBy>Hello Replaced By</dcterms:isReplacedBy>
+                    </oai_qdc:qualifieddc>>
+                </metadata>
+            </oai:record>
+        </x:context>
+        <x:expect label="dcterms:isReplacedBy is transformed to dcterms:isReplacedBy" test="oai_dc:dc/dcterms:isReplacedBy = 'Hello Replaced By'"/>
+    </x:scenario>
+
+    <!-- Replaces (QDC) -->
+
+    <x:scenario label="dcterms:replaces is transformed to dcterms:replaces">
+        <x:context>
+            <oai:record>
+                <metadata>
+                    <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/"
+                        xmlns:dcterms="http://purl.org/dc/terms/"
+                        xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+                        <dcterms:replaces>Goodbye Replaces</dcterms:replaces>
+                    </oai_qdc:qualifieddc>>
+                </metadata>
+            </oai:record>
+        </x:context>
+        <x:expect label="dcterms:replaces is transformed to dcterms:replaces" test="oai_dc:dc/dcterms:replaces = 'Goodbye Replaces'"/>
+    </x:scenario>
+
+    <!-- Rights -->
+
+    <x:scenario label="rights processing">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="rights URI is transformed to edm:rights" test="oai_dc:dc/edm:rights = 'http://rightsstatements.org/vocab/NoC-US/1.0/'"/>
+        <x:expect label="textual rights statment is transformed to dcterms:rights" test="oai_dc:dc/dcterms:rights = 'No Copyright - United States. The organization that has made the Item available believes that the Item is in the Public Domain under the laws of the United States, but a determination was not made as to its copyright status under the copyright laws of other countries. The Item may not be in the Public Domain under the laws of other countries. Please refer to the organization that has made the Item available for more information.'"/>
+    </x:scenario>
+
+    <!-- Rights holder (QDC) -->
+
+    <x:scenario label="dcterms:rightsholder is transformed to dcterms:rightsholder">
+        <x:context>
+            <oai:record>
+                <metadata>
+                    <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/"
+                        xmlns:dcterms="http://purl.org/dc/terms/"
+                        xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+                        <dcterms:rightsholder>This is a Rights Holder</dcterms:rightsholder>
+                    </oai_qdc:qualifieddc>>
+                </metadata>
+            </oai:record>
+        </x:context>
+        <x:expect label="dcterms:rightsholder is transformed to dcterms:rightsholder" test="oai_dc:dc/dcterms:rightsholder = 'This is a Rights Holder'"/>
+    </x:scenario>
+
+    <!-- Identifier -->
+
+    <x:scenario label="dc:identifier is transformed to dcterms:identifier">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="dc:identifer is transformed to dcterms:identifier" test="oai_dc:dc/dcterms:identifier = 'pitt:715.3420584.CP'"/>
+    </x:scenario>
+
+    <!-- Trackback URL -->
+
+    <x:scenario label="oai:identifier is transformed to edm:isShownAt">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="oai:identifier is transformed to edm:isShownAt" test="oai_dc:dc/edm:isShownAt = 'http://historicpittsburgh.org/islandora/object/pitt%3A715.3420584.CP'"/>
+    </x:scenario>
+
+    <!-- Thumbnail URL -->
+
+    <x:scenario label="dc:identifier.thumbnail is transformed to edm:preview">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="dc:identifier.thumbnail is transformed to edm:preview" test="oai_dc:dc/edm:preview = 'http://historicpittsburgh.org/islandora/object/pitt%3A715.3420584.CP/datastream/TN/view/Overbrook%20School.jpg'"/>
+    </x:scenario>
+
+    <!-- Intermediate provider -->
+
+    <x:scenario label="hard coded intermediate provider">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="hard coded intermediate provider" test="oai_dc:dc/dpla:intermediateProvider= 'Historic Pittsburgh'"/>
+    </x:scenario>
+
+    <!-- Hub -->
+
+    <x:scenario label="hard coded hub name">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="hard coded hub name" test="oai_dc:dc/edm:provider = 'PA Digital'"/>
+    </x:scenario>
+
+</x:description>

--- a/tests/xslt/historicpitt.xspec
+++ b/tests/xslt/historicpitt.xspec
@@ -194,7 +194,7 @@
                             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                             xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
                             <dcterms:alternative>Hello Alternate Title</dcterms:alternative>
-                        </oai_qdc:qualifieddc>>
+                        </oai_qdc:qualifieddc>
                     </metadata>
                 </oai:record>
             </x:context>
@@ -704,7 +704,7 @@
                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                         xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
                         <dcterms:spatial>Place 2</dcterms:spatial>
-                    </oai_qdc:qualifieddc>>
+                    </oai_qdc:qualifieddc>
                 </metadata>
             </oai:record>
         </x:context>
@@ -723,7 +723,7 @@
                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                         xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
                         <dcterms:temporal>Hello Temporal Coverage</dcterms:temporal>
-                    </oai_qdc:qualifieddc>>
+                    </oai_qdc:qualifieddc>
                 </metadata>
             </oai:record>
         </x:context>
@@ -742,7 +742,7 @@
                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                         xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
                         <dcterms:extent>300 pages</dcterms:extent>
-                    </oai_qdc:qualifieddc>>
+                    </oai_qdc:qualifieddc>
                 </metadata>
             </oai:record>
         </x:context>
@@ -827,7 +827,7 @@
                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                         xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
                         <dcterms:isReplacedBy>Hello Replaced By</dcterms:isReplacedBy>
-                    </oai_qdc:qualifieddc>>
+                    </oai_qdc:qualifieddc>
                 </metadata>
             </oai:record>
         </x:context>
@@ -846,7 +846,7 @@
                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                         xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
                         <dcterms:replaces>Goodbye Replaces</dcterms:replaces>
-                    </oai_qdc:qualifieddc>>
+                    </oai_qdc:qualifieddc>
                 </metadata>
             </oai:record>
         </x:context>
@@ -873,7 +873,7 @@
                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                         xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
                         <dcterms:rightsholder>This is a Rights Holder</dcterms:rightsholder>
-                    </oai_qdc:qualifieddc>>
+                    </oai_qdc:qualifieddc>
                 </metadata>
             </oai:record>
         </x:context>

--- a/tests/xslt/historicpitt_static.xspec
+++ b/tests/xslt/historicpitt_static.xspec
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    xmlns:dpla="http://dp.la/about/map/"
+    xmlns:edm="http://www.europeana.eu/schemas/edm/"
+    xmlns:oclcdc="http://worldcat.org/xmlschemas/oclcdc-1.0/"
+    xmlns:oclcterms="http://purl.org/oclc/terms/"
+    xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+    xmlns:oai_dc='http://www.openarchives.org/OAI/2.0/oai_dc/'
+    xmlns:oclc="http://purl.org/oclc/terms/"
+    xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/"
+    xmlns:schema="http://schema.org"
+    xmlns:svcs="http://rdfs.org/sioc/services"
+    stylesheet="../../transforms/historicpitt_static.xsl">
+    
+    <!-- Drop deleted records --> 
+    
+    <x:scenario label="OAI Deleted Records are Skipped">
+        <x:context>
+            <oai:record>
+                <oai:header status="deleted">
+                    <identifier>oai:record-that-should-be-ignored</identifier>
+                    <setSpec>TEST1</setSpec>
+                </oai:header>
+                <metadata>
+                    <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
+                        http://www.openarchives.org/OAI/2.0/oai_dc.xsd"
+                        xmlns="http://purl.org/dc/elements/1.1/"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                        <title>Champaign County, Illinois</title>
+                        <creator>United States. Agricultureal Adjustment Administration</creator>
+                        <identifier>record-that-should-be-ignored</identifier>
+                    </oai_dc:dc>
+                </metadata>
+            </oai:record>
+            <oai:record>
+                <oai:header>
+                    <identifier>oai:record-that-should-be-kept</identifier>
+                    <setSpec>TEST2</setSpec>
+                </oai:header>
+                <metadata>
+                    <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
+                        http://www.openarchives.org/OAI/2.0/oai_dc.xsd"
+                        xmlns="http://purl.org/dc/elements/1.1/"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                        <title>Champaign County, Illinois</title>
+                        <creator>United States. Agricultureal Adjustment Administration</creator>
+                        <identifier>record-that-should-be-kept</identifier>
+                    </oai_dc:dc>
+                </metadata>
+            </oai:record>
+        </x:context>
+        <x:expect label="1 record remains" test="count(oai_dc:dc) = 1"/>
+        <x:expect label="OAI Record Identifier of 1 Record is record-that-should-be-kept"
+            test="oai_dc:dc/dcterms:identifier = 'record-that-should-be-kept'" />
+    </x:scenario>
+    
+    <!-- Filtered Identifiers -->
+        
+    <x:scenario label="Records with Filtered Identifiers are Skipped">
+    <x:context>
+      <oai:record>
+        <oai:header>
+          <identifier>oai:test-filter-record-1</identifier>
+          <setSpec>TEST1</setSpec>
+        </oai:header>
+        <metadata>
+          <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
+              http://www.openarchives.org/OAI/2.0/oai_dc.xsd"
+              xmlns="http://purl.org/dc/elements/1.1/"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+            <title>Champaign County, Illinois</title>
+            <creator>United States. Agricultureal Adjustment Administration</creator>
+            <identifier>test-filter-record-1</identifier>
+          </oai_dc:dc>
+        </metadata>
+      </oai:record>
+      <oai:record>
+        <oai:header>
+          <identifier>oai:record-that-should-be-kept</identifier>
+          <setSpec>TEST2</setSpec>
+        </oai:header>
+        <metadata>
+          <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
+                    http://www.openarchives.org/OAI/2.0/oai_dc.xsd"
+                    xmlns="http://purl.org/dc/elements/1.1/"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+            <title>Champaign County, Illinois</title>
+            <creator>United States. Agricultureal Adjustment Administration</creator>
+            <identifier>record-that-should-be-kept</identifier>
+          </oai_dc:dc>
+        </metadata>
+      </oai:record>
+      <oai:record>
+        <oai:header>
+          <identifier>oai:test-filter-record-2</identifier>
+          <setSpec>TEST3</setSpec>
+        </oai:header>
+        <metadata>
+          <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
+              http://www.openarchives.org/OAI/2.0/oai_dc.xsd"
+              xmlns="http://purl.org/dc/elements/1.1/"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+            <title>Champaign County, Illinois</title>
+            <creator>United States. Agricultureal Adjustment Administration</creator>
+            <identifier>test-filter-record-2</identifier>
+          </oai_dc:dc>
+        </metadata>
+      </oai:record>
+    </x:context>
+    <x:expect label="1 record remains" test="count(oai_dc:dc) = 1"/>
+    <x:expect label="Record Identifier of Record is not one of filtered records"
+      test="oai_dc:dc/dcterms:identifier != 'test-filter-record-1'" />
+    <x:expect label="Record Identifier of Record is not one of filtered records"
+      test="oai_dc:dc/dcterms:identifier != 'test-filter-record-2'" />
+  </x:scenario>
+
+    <!-- Title -->
+    
+    <x:scenario label="dc:title processing">
+        <x:context>
+            <oai:record>
+                <metadata>
+                    <oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+                        <title>First Title</title>
+                        <title>Second Title</title>
+                    </oai_dc:dc>
+                </metadata>
+            </oai:record>
+        </x:context>
+        <x:expect label="1st dc.title is transformed to dcterms:title" test="oai_dc:dc/dcterms:title = 'First Title'"/>
+        <x:expect label="2nd dc:title is transformed to dcterms:alternative" test="oai_dc:dc/dcterms:alternative = 'Second Title'"/>
+    </x:scenario>    
+    
+    <!-- Relation -->
+    
+    <x:scenario label="dc:relation is transformed to dcterms:relation">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="dc:relation is transformed to dcterms:relation" test="oai_dc:dc/dcterms:relation = 'Pittsburgh City Photographer Collection, 1901-2002'"/>
+    </x:scenario>
+    
+    <!-- Identifier -->
+    
+    <x:scenario label="dc:identifier is transformed to dcterms:identifier">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="dc:identifer is transformed to dcterms:identifier" test="oai_dc:dc/dcterms:identifier = 'pitt:715.3420584.CP'"/>
+    </x:scenario>
+    
+    <!-- URL processing -->
+    
+    <x:scenario label="dc:identifier.thumbnail is parsed into edm:isShownAt and edm:preview">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="edm:isShownAt is derived from thumbnail" test="oai_dc:dc/edm:isShownAt = 'http://historicpittsburgh.org/islandora/object/pitt%3A715.3420584.CP'" />
+        <x:expect label="dc:identifier.thumbnail is transformed to edm:preview" test="oai_dc:dc/edm:preview = 'http://historicpittsburgh.org/islandora/object/pitt%3A715.3420584.CP/datastream/TN/view/Overbrook%20School.jpg'"/>
+    </x:scenario>
+    
+    <!-- Collection name -->
+    <!-- Note issue with apostrophe in collection name -->
+    
+    <x:scenario label="hard coded collection name">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="hard coded collection name" test="oai_dc:dc/dcterms:isPartOf = 'Fur Trader\'s Journal'"/>
+    </x:scenario>
+
+    <!-- Intermediate provider -->
+    
+    <x:scenario label="hard coded intermediate provider">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="hard coded intermediate provider" test="oai_dc:dc/dpla:intermediateProvider= 'Historic Pittsburgh'"/>
+    </x:scenario>
+    
+    <!-- Data provider -->
+    
+    <x:scenario label="hard coded data provider">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="hard coded dataprovider" test="oai_dc:dc/edm:dataProvider= 'University of Pittsburgh'"/>
+    </x:scenario>
+    
+    <!-- Hub -->
+    
+    <x:scenario label="hard coded hub name">
+        <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
+        <x:expect label="hard coded hub name" test="oai_dc:dc/edm:provider = 'PA Digital'"/>
+    </x:scenario>
+
+</x:description>

--- a/tests/xslt/historicpitt_static.xspec
+++ b/tests/xslt/historicpitt_static.xspec
@@ -15,9 +15,9 @@
     xmlns:schema="http://schema.org"
     xmlns:svcs="http://rdfs.org/sioc/services"
     stylesheet="../../transforms/historicpitt_static.xsl">
-    
-    <!-- Drop deleted records --> 
-    
+
+    <!-- Drop deleted records -->
+
     <x:scenario label="OAI Deleted Records are Skipped">
         <x:context>
             <oai:record>
@@ -59,9 +59,9 @@
         <x:expect label="OAI Record Identifier of 1 Record is record-that-should-be-kept"
             test="oai_dc:dc/dcterms:identifier = 'record-that-should-be-kept'" />
     </x:scenario>
-    
+
     <!-- Filtered Identifiers -->
-        
+
     <x:scenario label="Records with Filtered Identifiers are Skipped">
     <x:context>
       <oai:record>
@@ -124,7 +124,7 @@
   </x:scenario>
 
     <!-- Title -->
-    
+
     <x:scenario label="dc:title processing">
         <x:context>
             <oai:record>
@@ -138,54 +138,54 @@
         </x:context>
         <x:expect label="1st dc.title is transformed to dcterms:title" test="oai_dc:dc/dcterms:title = 'First Title'"/>
         <x:expect label="2nd dc:title is transformed to dcterms:alternative" test="oai_dc:dc/dcterms:alternative = 'Second Title'"/>
-    </x:scenario>    
-    
+    </x:scenario>
+
     <!-- Relation -->
-    
+
     <x:scenario label="dc:relation is transformed to dcterms:relation">
         <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
         <x:expect label="dc:relation is transformed to dcterms:relation" test="oai_dc:dc/dcterms:relation = 'Pittsburgh City Photographer Collection, 1901-2002'"/>
     </x:scenario>
-    
+
     <!-- Identifier -->
-    
+
     <x:scenario label="dc:identifier is transformed to dcterms:identifier">
         <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
         <x:expect label="dc:identifer is transformed to dcterms:identifier" test="oai_dc:dc/dcterms:identifier = 'pitt:715.3420584.CP'"/>
     </x:scenario>
-    
+
     <!-- URL processing -->
-    
+
     <x:scenario label="dc:identifier.thumbnail is parsed into edm:isShownAt and edm:preview">
         <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
         <x:expect label="edm:isShownAt is derived from thumbnail" test="oai_dc:dc/edm:isShownAt = 'http://historicpittsburgh.org/islandora/object/pitt%3A715.3420584.CP'" />
         <x:expect label="dc:identifier.thumbnail is transformed to edm:preview" test="oai_dc:dc/edm:preview = 'http://historicpittsburgh.org/islandora/object/pitt%3A715.3420584.CP/datastream/TN/view/Overbrook%20School.jpg'"/>
     </x:scenario>
-    
+
     <!-- Collection name -->
     <!-- Note issue with apostrophe in collection name -->
-    
+
     <x:scenario label="hard coded collection name">
         <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
-        <x:expect label="hard coded collection name" test="oai_dc:dc/dcterms:isPartOf = 'Fur Trader\'s Journal'"/>
+        <x:expect label="hard coded collection name" test='oai_dc:dc/dcterms:isPartOf = "Fur Trader&apos;s Journal"'/>
     </x:scenario>
 
     <!-- Intermediate provider -->
-    
+
     <x:scenario label="hard coded intermediate provider">
         <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
         <x:expect label="hard coded intermediate provider" test="oai_dc:dc/dpla:intermediateProvider= 'Historic Pittsburgh'"/>
     </x:scenario>
-    
+
     <!-- Data provider -->
-    
+
     <x:scenario label="hard coded data provider">
         <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
         <x:expect label="hard coded dataprovider" test="oai_dc:dc/edm:dataProvider= 'University of Pittsburgh'"/>
     </x:scenario>
-    
+
     <!-- Hub -->
-    
+
     <x:scenario label="hard coded hub name">
         <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
         <x:expect label="hard coded hub name" test="oai_dc:dc/edm:provider = 'PA Digital'"/>

--- a/transforms/historicpitt.xsl
+++ b/transforms/historicpitt.xsl
@@ -2,35 +2,39 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dpla="http://dp.la/about/map/" xmlns:edm="http://www.europeana.eu/schemas/edm/" xmlns:oclcdc="http://worldcat.org/xmlschemas/oclcdc-1.0/" xmlns:padig="http://padigitial.org/ns/" xmlns:oclcterms="http://purl.org/oclc/terms/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:oclc="http://purl.org/oclc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:schema="http://schema.org" xmlns:svcs="http://rdfs.org/sioc/services" version="2.0">
     <xsl:output omit-xml-declaration="no" method="xml" encoding="UTF-8" indent="yes"/>
     <xsl:strip-space elements="*"/>
-
+    
     <!-- Use includes here if you need to separate out templates for either use specific to a dataset or use generic enough for multiple providers (like remediation.xslt). -->
-
-    <!-- For using this XSLT in Combine, you need to replace the following with an actionable HTTP link to the remediation XSLT, or load both XSLT into Combine then rename this to the filepath & name assigned to remediation.xslt within Combine. -->
-
-    <xsl:include href="/home/combine/data/combine/transformations/lookup.xsl"/>
-    <xsl:include href="/home/combine/data/combine/transformations/filter.xsl"/>
-
+    
+    <xsl:include href="remediations/lookup.xsl"/>
+    <xsl:include href="remediations/filter.xsl"/>
+    
+    <!-- For using this XSLT in Combine, you need to replace the following with an actionable HTTP link to the remediation XSLT, or load both XSLT into Combine then rename this to the filepath & name assigned to remediation.xslt within Combine.
+        
+        <xsl:include href="/home/combine/data/combine/transformations/lookup.xsl"/>
+        <xsl:include href="/home/combine/data/combine/transformations/filter.xsl"/>
+    -->
+    
     <!-- drop nodes we don't care about (header values, records marked deleted, specific relation fields) -->
     <xsl:template match="text() | @*"/>
-    <xsl:template match="//oai:record[oai:header[@status = 'deleted']]/*"/>
-    <xsl:template match="//oai:record[oai:metadata/oai_dc:dc/dc:relation[contains(string(), 'pdcp_noharvest')]]"/>
-
-    <!-- base record. Matches each OAI feed record that is mapped. Filters out records with dc:identifier values contained in remediation_filter.xsl -->
+    <xsl:template match="//oai:record[oai:header[@status='deleted']]/*"/>
+    
+    <!-- base record. Matches each OAI feed record that is mapped. Filters out records with dc:identifier values contained in remediations/filter.xsl -->
     <xsl:template match="//oai:record[not(oai:metadata/oai_dc:dc/dc:relation[contains(string(), 'pdcp_noharvest')])]">
         <oai_dc:dc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dpla="http://dp.la/about/map/" xmlns:edm="http://www.europeana.eu/schemas/edm/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:oclc="http://purl.org/oclc/terms/" xmlns:oclcdc="http://worldcat.org/xmlschemas/oclcdc-1.0/" xmlns:oclcterms="http://purl.org/oclc/terms/" xmlns:schema="http://schema.org">
-
+            
             <!-- will match specific templates that relevant for dplah. -->
             <xsl:apply-templates/>
-
+            
             <!-- add templates you have to call - e.g. named templates; matched templates with mode -->
             <xsl:call-template name="intprovider"/>
             <xsl:call-template name="hub"/>
         </oai_dc:dc>
     </xsl:template>
-
+    
     <!-- HISTORIC-PITTSBURGH-SPECIFIC IDENTITY TEMPLATES -->
-
+    
     <!-- OAI Header SetSpec -->
+    
     <xsl:template match="oai:header/oai:setSpec">
         <xsl:if test="normalize-space(lower-case(.))">
             <xsl:variable name="setID" select="normalize-space(lower-case(.))"/>
@@ -41,7 +45,7 @@
             </xsl:if>
         </xsl:if>
     </xsl:template>
-
+    
     <!-- Title -->
     <xsl:template match="dc:title[1]">
         <xsl:if test="normalize-space(.) != ''">
@@ -50,20 +54,20 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-
+    
     <xsl:template match="dc:contributor">
         <xsl:variable name="contributingInst" select="substring-before(., &quot; (depositor)&quot;)"/>
         <xsl:if test="normalize-space(.) != ''">
-
-   <!-- Contributing Institution -->
+            
+            <!-- Contributing Institution -->
             <xsl:choose>
                 <xsl:when test="ends-with(., '(depositor)')">
                     <xsl:element name="edm:dataProvider">
                         <xsl:value-of select="$contributingInst"/>
                     </xsl:element>
                 </xsl:when>
-
-   <!-- Contributor -->
+                
+                <!-- Contributor -->
                 <xsl:otherwise>
                     <xsl:if test="normalize-space(.) != ''">
                         <xsl:element name="dcterms:contributor">
@@ -74,8 +78,8 @@
             </xsl:choose>
         </xsl:if>
     </xsl:template>
-
-
+    
+    
     <!-- Alternative titles -->
     <xsl:template match="dcterms:alternative">
         <xsl:if test="normalize-space(.) != ''">
@@ -84,7 +88,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-
+    
     <xsl:template match="dc:title[position() &gt; 1]">
         <xsl:if test="normalize-space(.)!=''">
             <dcterms:alternative>
@@ -92,7 +96,7 @@
             </dcterms:alternative>
         </xsl:if>
     </xsl:template>
-
+    
     <!-- Type -->
     <xsl:template match="dc:type">
         <xsl:if test="normalize-space(.) != ''">
@@ -127,7 +131,7 @@
             </xsl:choose>
         </xsl:if>
     </xsl:template>
-
+    
     <!-- Creator -->
     <xsl:template match="dc:creator">
         <xsl:if test="normalize-space(.) != ''">
@@ -136,7 +140,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-
+    
     <!-- Source -->
     <xsl:template match="dc:source">
         <xsl:if test="normalize-space(.) != ''">
@@ -145,7 +149,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-
+    
     <!-- Publisher -->
     <xsl:template match="dc:publisher">
         <xsl:if test="normalize-space(.) != ''">
@@ -154,7 +158,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-
+    
     <!-- Description -->
     <xsl:template match="dc:description">
         <xsl:if test="normalize-space(.) != ''">
@@ -163,7 +167,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-
+    
     <!-- Place (when oai_dc used) -->
     <xsl:template match="dc:coverage">
         <xsl:if test="normalize-space(.) != ''">
@@ -172,7 +176,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-
+    
     <!-- Place -->
     <xsl:template match="dcterms:spatial">
         <xsl:if test="normalize-space(.) != ''">
@@ -181,7 +185,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-
+    
     <!-- Temporal coverage -->
     <xsl:template match="dcterms:temporal">
         <xsl:if test="normalize-space(.) != ''">
@@ -190,7 +194,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-
+    
     <!-- Extent -->
     <xsl:template match="dcterms:extent">
         <xsl:if test="normalize-space(.) != ''">
@@ -199,7 +203,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-
+    
     <!-- Date -->
     <xsl:template match="dc:date">
         <xsl:if test="normalize-space(.) != ''">
@@ -208,7 +212,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-
+    
     <!-- Subject -->
     <xsl:template match="dc:subject">
         <xsl:call-template name="subj_template">
@@ -216,7 +220,7 @@
             <xsl:with-param name="delimiter" select="';'"/>
         </xsl:call-template>
     </xsl:template>
-
+    
     <!-- Language -->
     <xsl:template match="dc:language">
         <xsl:if test="normalize-space(.) != ''">
@@ -225,7 +229,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-
+    
     <!-- Relation -->
     <xsl:template match="dc:relation">
         <xsl:if test="normalize-space(.) != ''">
@@ -234,7 +238,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-
+    
     <!-- Replaced by -->
     <xsl:template match="dcterms:isReplacedBy">
         <xsl:if test="normalize-space(.) != ''">
@@ -243,7 +247,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-
+    
     <!-- Replaces -->
     <xsl:template match="dcterms:replaces">
         <xsl:if test="normalize-space(.) != ''">
@@ -252,7 +256,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-
+    
     <!-- Rights -->
     <xsl:template match="dc:rights">
         <xsl:choose>
@@ -274,7 +278,7 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-
+    
     <!-- Rights holder -->
     <xsl:template match="dcterms:rightsholder">
         <xsl:if test="normalize-space(.) != ''">
@@ -283,7 +287,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-
+    
     <!-- Identifier -->
     <xsl:template match="dc:identifier">
         <xsl:if test="normalize-space(.) != ''">
@@ -292,7 +296,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-
+    
     <!-- Trackback URL -->
     <xsl:template match="//oai:metadata/oai_dc:dc/oai:identifier">
         <xsl:if test="normalize-space(.) != ''">
@@ -301,7 +305,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-
+    
     <!-- Thumbnail URL -->
     <xsl:template match="dc:identifier.thumbnail">
         <xsl:if test="normalize-space(.) != ''">
@@ -310,29 +314,29 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-
-
+    
+    
     <!-- HISTORIC-PITTSBURGH-SPECIFIC NAMED TEMPLATES -->
-
+    
     <!-- Intermediate provider -->
-    <xsl:template name="intprovider">
+    <xsl:template name="intprovider">        
         <xsl:element name="dpla:intermediateProvider">
             <xsl:value-of>Historic Pittsburgh</xsl:value-of>
-        </xsl:element>
+        </xsl:element>       
     </xsl:template>
-
+    
     <!-- Hub -->
     <xsl:template name="hub">
         <xsl:element name="edm:provider">
             <xsl:value-of>PA Digital</xsl:value-of>
-        </xsl:element>
+        </xsl:element>     
     </xsl:template>
-
+    
     <!-- Subject -->
     <xsl:template name="subj_template">
         <xsl:param name="stringz"/>
         <xsl:param name="delimiter"/>
-
+        
         <xsl:choose>
             <!-- IF A PAREN, STOP AT AN OPENING semicolon -->
             <xsl:when test="contains($stringz, $delimiter)">
@@ -340,7 +344,7 @@
                 <dcterms:subject>
                     <xsl:value-of select="substring-before($stringz, $delimiter)"/>
                 </dcterms:subject>
-
+                
                 <!--Need to do recursion-->
                 <xsl:call-template name="subj_template">
                     <xsl:with-param name="stringz" select="$newstem"/>
@@ -354,12 +358,12 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-
+    
     <!-- Type -->
     <xsl:template name="type_template">
         <xsl:param name="stringz"/>
         <xsl:param name="delimiter"/>
-
+        
         <xsl:choose>
             <!-- IF A PAREN, STOP AT AN OPENING semicolon -->
             <xsl:when test="contains($stringz, $delimiter)">
@@ -367,7 +371,7 @@
                 <dcterms:type>
                     <xsl:value-of select="substring-before($stringz, $delimiter)"/>
                 </dcterms:type>
-
+                
                 <!--Need to do recursion-->
                 <xsl:call-template name="type_template">
                     <xsl:with-param name="stringz" select="$newstem"/>
@@ -381,12 +385,12 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-
+    
     <!-- Language -->
     <xsl:template name="lang_template">
         <xsl:param name="stringz"/>
         <xsl:param name="delimiter"/>
-
+        
         <xsl:choose>
             <!-- IF A PAREN, STOP AT AN OPENING semicolon -->
             <xsl:when test="contains($stringz, $delimiter)">
@@ -394,7 +398,7 @@
                 <dcterms:language>
                     <xsl:value-of select="substring-before($stringz, $delimiter)"/>
                 </dcterms:language>
-
+                
                 <!--Need to do recursion-->
                 <xsl:call-template name="lang_template">
                     <xsl:with-param name="stringz" select="$newstem"/>

--- a/transforms/historicpitt_static.xsl
+++ b/transforms/historicpitt_static.xsl
@@ -23,7 +23,7 @@
 
     <xsl:include href="remediations/lookup.xsl"/>
     <xsl:include href="remediations/filter.xsl"/>
-    
+
     <!-- For using this XSLT in Combine, you need to replace the following with an actionable HTTP link to the remediation XSLT, or load both XSLT into Combine then rename this to the filepath & name assigned to remediation.xslt within Combine.
     <xsl:include href="https://raw.githubusercontent.com/tulibraries/aggregator_mdx/master/transforms/temple.xsl"/>
     <xsl:include href="https://raw.githubusercontent.com/tulibraries/aggregator_mdx/master/transforms/remediations/filter.xsl"/>
@@ -54,14 +54,14 @@
 
             <!-- add templates you have to call - e.g. named templates; matched templates with mode -->
             <xsl:call-template name="hub"/>
-            <xsl:element name="dcterms:isPartOf"><xsl:value-of>Fur Trader's Journal</xsl:value-of></xsl:element>
+            <xsl:element name="dcterms:isPartOf"><xsl:value-of>Fur Trader&apos;s Journal</xsl:value-of></xsl:element>
             <xsl:element name="dpla:intermediateProvider">
                     <xsl:value-of>Historic Pittsburgh</xsl:value-of>
             </xsl:element>
             <xsl:element name="edm:dataProvider">
                 <xsl:value-of>University of Pittsburgh</xsl:value-of>
             </xsl:element>
-            
+
         </oai_dc:dc>
     </xsl:template>
 
@@ -75,7 +75,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-    
+
     <!-- Alternative titles -->
     <xsl:template match="dc:title[position() > 1]">
         <xsl:if test="normalize-space(.)!=''">
@@ -84,7 +84,7 @@
             </dcterms:alternative>
         </xsl:if>
     </xsl:template>
-    
+
     <!-- Contributor
     <xsl:template match="dc:contributor[position() != last()]">
         <xsl:if test="normalize-space(.)!=''">
@@ -103,7 +103,7 @@
         </xsl:if>
     </xsl:template>
     -->
-     
+
 
      <!-- File format
     <xsl:template match="dc:format">
@@ -114,7 +114,7 @@
         </xsl:if>
     </xsl:template>
      -->
-    
+
     <!-- Relation -->
     <xsl:template match="dc:relation">
         <xsl:if test="normalize-space(.)!=''">
@@ -123,7 +123,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-    
+
     <!-- Identifier -->
     <xsl:template match="dc:identifier">
         <xsl:if test="normalize-space(.)!=''">
@@ -145,7 +145,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-    
+
     <!-- Hub -->
     <xsl:template name="hub">
         <xsl:element name="edm:provider">
@@ -154,5 +154,3 @@
     </xsl:template>
 
 </xsl:stylesheet>
-
-

--- a/transforms/historicpitt_static.xsl
+++ b/transforms/historicpitt_static.xsl
@@ -20,17 +20,21 @@
     <xsl:strip-space elements="*"/>
 
      <!-- Use includes here if you need to separate out templates for either use specific to a dataset or use generic enough for multiple providers (like remediation.xslt). -->
-    <!-- For using this XSLT in Combine, you need to replace the following with an actionable HTTP link to the remediation XSLT, or load both XSLT into Combine then rename this to the filepath & name assigned to remediation.xslt within Combine. -->
+
+    <xsl:include href="remediations/lookup.xsl"/>
+    <xsl:include href="remediations/filter.xsl"/>
+    
+    <!-- For using this XSLT in Combine, you need to replace the following with an actionable HTTP link to the remediation XSLT, or load both XSLT into Combine then rename this to the filepath & name assigned to remediation.xslt within Combine.
     <xsl:include href="https://raw.githubusercontent.com/tulibraries/aggregator_mdx/master/transforms/temple.xsl"/>
     <xsl:include href="https://raw.githubusercontent.com/tulibraries/aggregator_mdx/master/transforms/remediations/filter.xsl"/>
-
+-->
      <!-- drop nodes we don't care about, namely, header values -->
     <xsl:template match="text() | @*"/>
 
      <!-- drop records where the OAI header is marked as 'deleted' -->
     <xsl:template match="//oai:record[oai:header[@status='deleted']]/*"/>
 
-     <!-- base record. Matches each OAI feed record that is mapped. Filters out records with dc:identifier values contained in remediation_filter.xsl -->
+     <!-- base record. Matches each OAI feed record that is mapped. Filters out records with dc:identifier values contained in remediations/filter.xsl -->
     <xsl:template match="//oai_dc:dc[not(dc:identifier[string() = $filterids])]">
         <oai_dc:dc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns:dc="http://purl.org/dc/elements/1.1/"
@@ -140,6 +144,13 @@
                 <xsl:value-of select="normalize-space(.)"/>
             </xsl:element>
         </xsl:if>
+    </xsl:template>
+    
+    <!-- Hub -->
+    <xsl:template name="hub">
+        <xsl:element name="edm:provider">
+            <xsl:value-of>PA Digital</xsl:value-of>
+        </xsl:element>
     </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Making separate PR to show fixes:
- addresses lack of test output by removing `set -e` from bash script that runs tests in CI
- fixes unescaped apostrophe (issue with XML)
- updates Pipfile