### PR TITLE
remove set -e from test bash script; fix unescaped apos

### DIFF
--- a/.circleci/tests.sh
+++ b/.circleci/tests.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
-set -e
 
 for xspectest in $(ls tests/xslt/*.xspec); do \
 docker run xspec "$xspectest" &> .circleci/result.log;
     if grep -q ".*failed:\s[1-9]" .circleci/result.log || grep -q -E "\*+\sError\s(running|compiling)\sthe\stest\ssuite" .circleci/result.log;
-        then
-            echo "FAILED: $xspectest";
-            echo "---------- result.log";
-            cat .circleci/result.log;
-            echo "----------";
-            exit 1;
-        else echo "OK: $xspectest";
+      then
+          echo "FAILED: $xspectest";
+          echo "---------- result.log";
+          cat .circleci/result.log;
+          echo "----------";
+          exit 1;
+      else echo "OK: $xspectest";
     fi
 done
 

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+
+[requires]
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,20 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "7e7ef69da7248742e869378f8421880cf8f0017f96d94d086813baa518a65489"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {},
+    "develop": {}
+}

--- a/tests/xslt/historicpitt_static.xspec
+++ b/tests/xslt/historicpitt_static.xspec
@@ -15,9 +15,9 @@
     xmlns:schema="http://schema.org"
     xmlns:svcs="http://rdfs.org/sioc/services"
     stylesheet="../../transforms/historicpitt_static.xsl">
-    
-    <!-- Drop deleted records --> 
-    
+
+    <!-- Drop deleted records -->
+
     <x:scenario label="OAI Deleted Records are Skipped">
         <x:context>
             <oai:record>
@@ -59,9 +59,9 @@
         <x:expect label="OAI Record Identifier of 1 Record is record-that-should-be-kept"
             test="oai_dc:dc/dcterms:identifier = 'record-that-should-be-kept'" />
     </x:scenario>
-    
+
     <!-- Filtered Identifiers -->
-        
+
     <x:scenario label="Records with Filtered Identifiers are Skipped">
     <x:context>
       <oai:record>
@@ -124,7 +124,7 @@
   </x:scenario>
 
     <!-- Title -->
-    
+
     <x:scenario label="dc:title processing">
         <x:context>
             <oai:record>
@@ -138,54 +138,54 @@
         </x:context>
         <x:expect label="1st dc.title is transformed to dcterms:title" test="oai_dc:dc/dcterms:title = 'First Title'"/>
         <x:expect label="2nd dc:title is transformed to dcterms:alternative" test="oai_dc:dc/dcterms:alternative = 'Second Title'"/>
-    </x:scenario>    
-    
+    </x:scenario>
+
     <!-- Relation -->
-    
+
     <x:scenario label="dc:relation is transformed to dcterms:relation">
         <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
         <x:expect label="dc:relation is transformed to dcterms:relation" test="oai_dc:dc/dcterms:relation = 'Pittsburgh City Photographer Collection, 1901-2002'"/>
     </x:scenario>
-    
+
     <!-- Identifier -->
-    
+
     <x:scenario label="dc:identifier is transformed to dcterms:identifier">
         <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
         <x:expect label="dc:identifer is transformed to dcterms:identifier" test="oai_dc:dc/dcterms:identifier = 'pitt:715.3420584.CP'"/>
     </x:scenario>
-    
+
     <!-- URL processing -->
-    
+
     <x:scenario label="dc:identifier.thumbnail is parsed into edm:isShownAt and edm:preview">
         <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
         <x:expect label="edm:isShownAt is derived from thumbnail" test="oai_dc:dc/edm:isShownAt = 'http://historicpittsburgh.org/islandora/object/pitt%3A715.3420584.CP'" />
         <x:expect label="dc:identifier.thumbnail is transformed to edm:preview" test="oai_dc:dc/edm:preview = 'http://historicpittsburgh.org/islandora/object/pitt%3A715.3420584.CP/datastream/TN/view/Overbrook%20School.jpg'"/>
     </x:scenario>
-    
+
     <!-- Collection name -->
     <!-- Note issue with apostrophe in collection name -->
-    
+
     <x:scenario label="hard coded collection name">
         <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
-        <x:expect label="hard coded collection name" test="oai_dc:dc/dcterms:isPartOf = 'Fur Trader\'s Journal'"/>
+        <x:expect label="hard coded collection name" test='oai_dc:dc/dcterms:isPartOf = "Fur Trader&apos;s Journal"'/>
     </x:scenario>
 
     <!-- Intermediate provider -->
-    
+
     <x:scenario label="hard coded intermediate provider">
         <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
         <x:expect label="hard coded intermediate provider" test="oai_dc:dc/dpla:intermediateProvider= 'Historic Pittsburgh'"/>
     </x:scenario>
-    
+
     <!-- Data provider -->
-    
+
     <x:scenario label="hard coded data provider">
         <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
         <x:expect label="hard coded dataprovider" test="oai_dc:dc/edm:dataProvider= 'University of Pittsburgh'"/>
     </x:scenario>
-    
+
     <!-- Hub -->
-    
+
     <x:scenario label="hard coded hub name">
         <x:context href="../../fixtures/historicpitt_test.oaidc_2.xml"/>
         <x:expect label="hard coded hub name" test="oai_dc:dc/edm:provider = 'PA Digital'"/>

--- a/transforms/historicpitt_static.xsl
+++ b/transforms/historicpitt_static.xsl
@@ -23,7 +23,7 @@
 
     <xsl:include href="remediations/lookup.xsl"/>
     <xsl:include href="remediations/filter.xsl"/>
-    
+
     <!-- For using this XSLT in Combine, you need to replace the following with an actionable HTTP link to the remediation XSLT, or load both XSLT into Combine then rename this to the filepath & name assigned to remediation.xslt within Combine.
     <xsl:include href="https://raw.githubusercontent.com/tulibraries/aggregator_mdx/master/transforms/temple.xsl"/>
     <xsl:include href="https://raw.githubusercontent.com/tulibraries/aggregator_mdx/master/transforms/remediations/filter.xsl"/>
@@ -54,14 +54,14 @@
 
             <!-- add templates you have to call - e.g. named templates; matched templates with mode -->
             <xsl:call-template name="hub"/>
-            <xsl:element name="dcterms:isPartOf"><xsl:value-of>Fur Trader's Journal</xsl:value-of></xsl:element>
+            <xsl:element name="dcterms:isPartOf"><xsl:value-of>Fur Trader&apos;s Journal</xsl:value-of></xsl:element>
             <xsl:element name="dpla:intermediateProvider">
                     <xsl:value-of>Historic Pittsburgh</xsl:value-of>
             </xsl:element>
             <xsl:element name="edm:dataProvider">
                 <xsl:value-of>University of Pittsburgh</xsl:value-of>
             </xsl:element>
-            
+
         </oai_dc:dc>
     </xsl:template>
 
@@ -75,7 +75,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-    
+
     <!-- Alternative titles -->
     <xsl:template match="dc:title[position() > 1]">
         <xsl:if test="normalize-space(.)!=''">
@@ -84,7 +84,7 @@
             </dcterms:alternative>
         </xsl:if>
     </xsl:template>
-    
+
     <!-- Contributor
     <xsl:template match="dc:contributor[position() != last()]">
         <xsl:if test="normalize-space(.)!=''">
@@ -103,7 +103,7 @@
         </xsl:if>
     </xsl:template>
     -->
-     
+
 
      <!-- File format
     <xsl:template match="dc:format">
@@ -114,7 +114,7 @@
         </xsl:if>
     </xsl:template>
      -->
-    
+
     <!-- Relation -->
     <xsl:template match="dc:relation">
         <xsl:if test="normalize-space(.)!=''">
@@ -123,7 +123,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-    
+
     <!-- Identifier -->
     <xsl:template match="dc:identifier">
         <xsl:if test="normalize-space(.)!=''">
@@ -145,7 +145,7 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-    
+
     <!-- Hub -->
     <xsl:template name="hub">
         <xsl:element name="edm:provider">
@@ -154,5 +154,3 @@
     </xsl:template>
 
 </xsl:stylesheet>
-
-


### PR DESCRIPTION
Making separate PR to show fixes:
- addresses lack of test output by removing `set -e` from bash script that runs tests in CI
- fixes unescaped apostrophe (issue with XML)
- updates Pipfile