### PR TITLE
Add dummy csv xsl

### DIFF
--- a/fixtures/free_library_test.csv.xml
+++ b/fixtures/free_library_test.csv.xml
@@ -1,0 +1,30 @@
+<collection dag-id="funcake_free_library_of_philadelphia" dag-timestamp="2019-11-27_16-54-14">
+  <record airflow-record-id="1">
+    <Item_No>frk00001</Item_No>
+    <Title>Birth and Baptismal Certificate (Geburts und Taufschein) for Jonas Laber</Title>
+    <Creator>Anonymous</Creator>
+    <Description>Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.</Description>
+    <Creation_Date>ca. 1825</Creation_Date>
+    <Format>tif</Format>
+    <Subject> Flowers | Planters (containers) | Pottery | Rosettes | Tulips</Subject>
+    <Language>German; English</Language>
+    <Identifier>http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001</Identifier>
+    <Thumbnail>http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg</Thumbnail>
+    <Type>Still Image</Type>
+    <Collection_Name>Fraktur</Collection_Name>
+  </record>
+  <record airflow-record-id="2">
+    <Item_No>frk00002</Item_No>
+    <Title>Birth and Baptismal Certificate (Geburts und Taufschein) for Johann Henrich Mes</Title>
+    <Creator>Karl E. Munch (1769-1833)</Creator>
+    <Description>Hand-drawn; hand-colored; hand-lettered. The main text is handwritten in German Fraktur and German script. Above and below the text are undulating vines with sheaves of grain protruding on each side. On the sides are rose stems and wreaths surrounding Biblical verses hand-written in Fraktur and German script. In the center are two clusters of various farm tools.</Description>
+    <Creation_Date>1799</Creation_Date>
+    <Format>tif</Format>
+    <Subject> Agriculture | Bible. N.T. Matthew | Bible. N.T. Timothy | Bible. O.T. Proverbs | Bible. O.T. Psalms | Biblical verses | Flowers | Fruit | Grains | Harrows | Ornaments | Plows | Roses | Scythes | Tools | Vines | Wreaths</Subject>
+    <Language>German</Language>
+    <Identifier>http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00002</Identifier>
+    <Thumbnail>http://libwww.freelibrary.org/digicol/fraktur/frk00002t.jpg</Thumbnail>
+    <Type>Still Image</Type>
+    <Collection_Name>Fraktur</Collection_Name>
+  </record>
+</collection>

--- a/fixtures/free_library_test.csv.xml
+++ b/fixtures/free_library_test.csv.xml
@@ -1,18 +1,4 @@
 <collection dag-id="funcake_free_library_of_philadelphia" dag-timestamp="2019-11-27_16-54-14">
-  <record airflow-record-id="1">
-    <Item_No>frk00001</Item_No>
-    <Title>Birth and Baptismal Certificate (Geburts und Taufschein) for Jonas Laber</Title>
-    <Creator>Anonymous</Creator>
-    <Description>Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.</Description>
-    <Creation_Date>ca. 1825</Creation_Date>
-    <Format>tif</Format>
-    <Subject> Flowers | Planters (containers) | Pottery | Rosettes | Tulips</Subject>
-    <Language>German; English</Language>
-    <Identifier>http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001</Identifier>
-    <Thumbnail>http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg</Thumbnail>
-    <Type>Still Image</Type>
-    <Collection_Name>Fraktur</Collection_Name>
-  </record>
   <record airflow-record-id="2">
     <Item_No>frk00002</Item_No>
     <Title>Birth and Baptismal Certificate (Geburts und Taufschein) for Johann Henrich Mes</Title>
@@ -24,6 +10,20 @@
     <Language>German</Language>
     <Identifier>http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00002</Identifier>
     <Thumbnail>http://libwww.freelibrary.org/digicol/fraktur/frk00002t.jpg</Thumbnail>
+    <Type>Still Image</Type>
+    <Collection_Name>Fraktur</Collection_Name>
+  </record>
+  <record airflow-record-id="1">
+    <Item_No>frk00001</Item_No>
+    <Title>Birth and Baptismal Certificate (Geburts und Taufschein) for Jonas Laber</Title>
+    <Creator>Anonymous</Creator>
+    <Description>Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.</Description>
+    <Creation_Date>ca. 1825</Creation_Date>
+    <Format>tif</Format>
+    <Subject> Flowers | Planters (containers) | Pottery | Rosettes | Tulips</Subject>
+    <Language>German; English</Language>
+    <Identifier>http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001</Identifier>
+    <Thumbnail>http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg</Thumbnail>
     <Type>Still Image</Type>
     <Collection_Name>Fraktur</Collection_Name>
   </record>

--- a/tests/xslt/free_library_csv.xspec
+++ b/tests/xslt/free_library_csv.xspec
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    xmlns:dpla="http://dp.la/about/map/"
+    xmlns:edm="http://www.europeana.eu/schemas/edm/"
+    xmlns:oclcdc="http://worldcat.org/xmlschemas/oclcdc-1.0/"
+    xmlns:oclcterms="http://purl.org/oclc/terms/"
+    xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+    xmlns:oai_dc='http://www.openarchives.org/OAI/2.0/oai_dc/'
+    xmlns:oclc="http://purl.org/oclc/terms/"
+    xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/"
+    xmlns:schema="http://schema.org"
+    xmlns:svcs="http://rdfs.org/sioc/services"
+    stylesheet="../../transforms/free_library_csv.xsl">
+
+    <!-- Collection Name -->
+    <x:scenario label="Collection_Name is transformed to dcterms:isPartOf">
+      <x:context href="../../fixtures/free_library_test.csv.xml"/>
+      <x:expect label="Collection_Name is transformed to dcterms:isPartOf" test="oai_dc:dc/dcterms:isPartOf = 'Fraktur'"/>
+    </x:scenario>
+
+    <!-- Contributing Institution -->
+    <x:scenario label="hard coded dataProvider">
+      <x:context href="../../fixtures/free_library_test.csv.xml"/>
+      <x:expect label="hard coded dataProvider" test="oai_dc:dc/edm:dataProvider = 'Free Library of Philadelphia'"/>
+    </x:scenario>
+
+    <!-- Creator -->
+    <x:scenario label="Creator is transformed to dcterms:creator">
+      <x:context href="../../fixtures/free_library_test.csv.xml"/>
+      <x:expect label="Creator is transformed to dcterms:creator" test="oai_dc:dc/dcterms:creator = 'Anonymous'"/>
+    </x:scenario>
+
+    <!-- Date -->
+    <x:scenario label="Creation_Date is transformed to dcterms:date">
+      <x:context href="../../fixtures/free_library_test.csv.xml"/>
+      <x:expect label="Creation_Date is transformed to dcterms:date" test="oai_dc:dc/dcterms:date = 'ca. 1825'"/>
+    </x:scenario>
+
+    <!-- Description -->
+    <x:scenario label="Description is transformed to dcterms:description">
+      <x:context href="../../fixtures/free_library_test.csv.xml"/>
+      <x:expect label="Description is transformed to dcterms:description" test="oai_dc:dc/dcterms:description = 'Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.'"/>
+    </x:scenario>
+
+    <!-- Hub -->
+    <x:scenario label="hard coded hub name">
+      <x:context href="../../fixtures/free_library_test.csv.xml"/>
+      <x:expect label="hard coded hub name" test="oai_dc:dc/edm:provider = 'PA Digital'"></x:expect>
+    </x:scenario>
+
+    <!-- Identifiers -->
+    <x:scenario label="identifier processing">
+      <x:context href="../../fixtures/free_library_test.csv.xml"/>
+        <x:expect label="Item_No is derived from base URL" test="oai_dc:dc/dcterms:identifier = 'frk00001'"/>
+        <x:expect label="Identifier is transformed to edm:isShownAt" test="oai_dc:dc/edm:isShownAt = 'http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001'"/>
+      <x:expect label="Thumbnail is generated from identifier" test="oai_dc:dc/edm:preview = 'http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg'"></x:expect>
+    </x:scenario>
+
+    <!-- Language -->
+    <x:scenario label="Language is transformed to dcterms:language">
+      <x:context href="../../fixtures/free_library_test.csv.xml"/>
+      <x:expect label="Language is transformed to dcterms:language" test="oai_dc:dc/dcterms:language = 'German; English'"/>
+    </x:scenario>
+
+    <!-- Rights -->
+    <x:scenario label="rights processing">
+      <x:context href="../../fixtures/free_library_test.csv.xml"/>
+        <x:expect label="textual rights statment is transformed to dcterms:rights" test="oai_dc:dc/dcterms:rights = 'High-resolution images from the Free Library of Philadelphia's collections are available for publication and other uses, within copyright and licensing restrictions. Please take note of the Item No which you will need to fill out the Reproduction Services form.'"/>
+    </x:scenario>
+
+    <!-- Subject -->
+    <x:scenario label="Subject is transformed to dcterms:subject">
+      <x:context href="../../fixtures/free_library_test.csv.xml"/>
+      <x:expect label="Subject is transformed to dcterms:subject" test="oai_dc:dc/dcterms:subject = 'Tulips'"/>
+    </x:scenario>
+
+    <!-- Title -->
+    <x:scenario label="Title is transformed to dcterms:title">
+      <x:context href="../../fixtures/free_library_test.csv.xml"/>
+      <x:expect label="Title is transformed to dcterms:title" test="oai_dc:dc/dcterms:title = 'Birth and Baptismal Certificate (Geburts und Taufschein) for Jonas Laber'"/>
+    </x:scenario>
+
+    <!-- Type -->
+    <x:scenario label="Type are matched and remediated for known strings">
+      <x:scenario label="Image Type Remediation">
+        <x:scenario label="Image Type Remediation: Starts with lowercase image">
+          <x:context>
+            <record>
+              <Type>Still Image</Type>
+              <Item_No>record-that-should-be-kept</Item_No>
+            </record>
+          </x:context>
+          <x:expect label="Output record Type is 'Still Image'" test="oai_dc:dc/dcterms:type = 'Still Image'" />
+        </x:scenario>
+      </x:scenario>
+    </x:scenario>
+</x:description>

--- a/tests/xslt/free_library_csv.xspec
+++ b/tests/xslt/free_library_csv.xspec
@@ -1,102 +1,101 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
-    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:dc="http://purl.org/dc/elements/1.1/"
-    xmlns:dcterms="http://purl.org/dc/terms/"
-    xmlns:dpla="http://dp.la/about/map/"
-    xmlns:edm="http://www.europeana.eu/schemas/edm/"
-    xmlns:oclcdc="http://worldcat.org/xmlschemas/oclcdc-1.0/"
-    xmlns:oclcterms="http://purl.org/oclc/terms/"
-    xmlns:oai="http://www.openarchives.org/OAI/2.0/"
-    xmlns:oai_dc='http://www.openarchives.org/OAI/2.0/oai_dc/'
-    xmlns:oclc="http://purl.org/oclc/terms/"
-    xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/"
-    xmlns:schema="http://schema.org"
-    xmlns:svcs="http://rdfs.org/sioc/services"
-    stylesheet="../../transforms/free_library_csv.xsl">
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:dcterms="http://purl.org/dc/terms/"
+  xmlns:dpla="http://dp.la/about/map/"
+  xmlns:edm="http://www.europeana.eu/schemas/edm/"
+  xmlns:oclcdc="http://worldcat.org/xmlschemas/oclcdc-1.0/"
+  xmlns:oclcterms="http://purl.org/oclc/terms/"
+  xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+  xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+  xmlns:oclc="http://purl.org/oclc/terms/"
+  xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/"
+  xmlns:schema="http://schema.org"
+  xmlns:svcs="http://rdfs.org/sioc/services"
+  stylesheet="../../transforms/free_library_csv.xsl">
 
-    <!-- Collection Name -->
-    <x:scenario label="Collection_Name is transformed to dcterms:isPartOf">
-      <x:context href="../../fixtures/free_library_test.csv.xml"/>
-      <x:expect label="Collection_Name is transformed to dcterms:isPartOf" test="oai_dc:dc/dcterms:isPartOf = 'Fraktur'"/>
-    </x:scenario>
+  <!-- Collection Name -->
+  <x:scenario label="Collection_Name is transformed to dcterms:isPartOf">
+    <x:context href="../../fixtures/free_library_test.csv.xml"/>
+    <x:expect label="Collection_Name is transformed to dcterms:isPartOf" test="oai_dc:dc/dcterms:isPartOf = 'Fraktur'"/>
+  </x:scenario>
 
-    <!-- Contributing Institution -->
-    <x:scenario label="hard coded dataProvider">
-      <x:context href="../../fixtures/free_library_test.csv.xml"/>
-      <x:expect label="hard coded dataProvider" test="oai_dc:dc/edm:dataProvider = 'Free Library of Philadelphia'"/>
-    </x:scenario>
+  <!-- Contributing Institution -->
+  <x:scenario label="hard coded dataProvider">
+    <x:context href="../../fixtures/free_library_test.csv.xml"/>
+    <x:expect label="hard coded dataProvider" test="oai_dc:dc/dpla:intermediateProvider = 'Free Library of Philadelphia'"/>
+  </x:scenario>
 
-    <!-- Creator -->
-    <x:scenario label="Creator is transformed to dcterms:creator">
-      <x:context href="../../fixtures/free_library_test.csv.xml"/>
-      <x:expect label="Creator is transformed to dcterms:creator" test="oai_dc:dc/dcterms:creator = 'Anonymous'"/>
-    </x:scenario>
+  <!-- Creator -->
+  <x:scenario label="Creator is transformed to dcterms:creator">
+    <x:context href="../../fixtures/free_library_test.csv.xml"/>
+    <x:expect label="Creator is transformed to dcterms:creator" test="oai_dc:dc/dcterms:creator = 'Anonymous'"/>
+  </x:scenario>
 
-    <!-- Date -->
-    <x:scenario label="Creation_Date is transformed to dcterms:date">
-      <x:context href="../../fixtures/free_library_test.csv.xml"/>
-      <x:expect label="Creation_Date is transformed to dcterms:date" test="oai_dc:dc/dcterms:date = 'ca. 1825'"/>
-    </x:scenario>
+  <!-- Date -->
+  <x:scenario label="Creation_Date is transformed to dcterms:date">
+    <x:context href="../../fixtures/free_library_test.csv.xml"/>
+    <x:expect label="Creation_Date is transformed to dcterms:date" test="oai_dc:dc/dcterms:date = 'ca. 1825'"/>
+  </x:scenario>
 
-    <!-- Description -->
-    <x:scenario label="Description is transformed to dcterms:description">
-      <x:context href="../../fixtures/free_library_test.csv.xml"/>
-      <x:expect label="Description is transformed to dcterms:description" test="oai_dc:dc/dcterms:description = 'Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.'"/>
-    </x:scenario>
+  <!-- Description -->
+  <x:scenario label="Description is transformed to dcterms:description">
+    <x:context href="../../fixtures/free_library_test.csv.xml"/>
+    <x:expect label="Description is transformed to dcterms:description" test="oai_dc:dc/dcterms:description = 'Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.'"/>
+  </x:scenario>
 
-    <!-- Hub -->
-    <x:scenario label="hard coded hub name">
-      <x:context href="../../fixtures/free_library_test.csv.xml"/>
-      <x:expect label="hard coded hub name" test="oai_dc:dc/edm:provider = 'PA Digital'"></x:expect>
-    </x:scenario>
+  <!-- Hub -->
+  <x:scenario label="hard coded hub name">
+    <x:context href="../../fixtures/free_library_test.csv.xml"/>
+    <x:expect label="hard coded hub name" test="oai_dc:dc/edm:provider = 'PA Digital'"></x:expect>
+  </x:scenario>
 
-    <!-- Identifiers -->
-    <x:scenario label="identifier processing">
-      <x:context href="../../fixtures/free_library_test.csv.xml"/>
-        <x:expect label="Item_No is derived from base URL" test="oai_dc:dc/dcterms:identifier = 'frk00001'"/>
-        <x:expect label="Identifier is transformed to edm:isShownAt" test="oai_dc:dc/edm:isShownAt = 'http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001'"/>
-      <x:expect label="Thumbnail is generated from identifier" test="oai_dc:dc/edm:preview = 'http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg'"></x:expect>
-    </x:scenario>
+  <!-- Identifiers -->
+  <x:scenario label="identifier processing">
+    <x:context href="../../fixtures/free_library_test.csv.xml"/>
+      <x:expect label="Item_No is derived from base URL" test="oai_dc:dc/dcterms:identifier = 'frk00001'"/>
+      <x:expect label="Identifier is transformed to edm:isShownAt" test="oai_dc:dc/edm:isShownAt = 'http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001'"/>
+    <x:expect label="Thumbnail is generated from identifier" test="oai_dc:dc/edm:preview = 'http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg'"></x:expect>
+  </x:scenario>
 
-    <!-- Language -->
-    <x:scenario label="Language is transformed to dcterms:language">
-      <x:context href="../../fixtures/free_library_test.csv.xml"/>
-      <x:expect label="Language is transformed to dcterms:language" test="oai_dc:dc/dcterms:language = 'German; English'"/>
-    </x:scenario>
+  <!-- Language -->
+  <x:scenario label="Language is transformed to dcterms:language">
+    <x:context href="../../fixtures/free_library_test.csv.xml"/>
+    <x:expect label="Language is transformed to dcterms:language" test="oai_dc:dc/dcterms:language = 'German; English'"/>
+  </x:scenario>
 
-    <!-- Rights -->
-    <x:scenario label="rights processing">
-      <x:context href="../../fixtures/free_library_test.csv.xml"/>
-        <x:expect label="textual rights statment is transformed to dcterms:rights" test="oai_dc:dc/dcterms:rights = 'High-resolution images from the Free Library of Philadelphia's collections are available for publication and other uses, within copyright and licensing restrictions. Please take note of the Item No which you will need to fill out the Reproduction Services form.'"/>
-    </x:scenario>
+  <!-- Rights -->
+  <x:scenario label="rights processing">
+    <x:context href="../../fixtures/free_library_test.csv.xml"/>
+    <x:expect label="textual rights statment is transformed to dcterms:rights" test='oai_dc:dc/dcterms:rights = "High-resolution images from the Free Library of Philadelphia&apos;s collections are available for publication and other uses, within copyright and licensing restrictions. Please take note of the Item No which you will need to fill out the Reproduction Services form."'/>
+  </x:scenario>
 
-    <!-- Subject -->
-    <x:scenario label="Subject is transformed to dcterms:subject">
-      <x:context href="../../fixtures/free_library_test.csv.xml"/>
-      <x:expect label="Subject is transformed to dcterms:subject" test="oai_dc:dc/dcterms:subject = 'Tulips'"/>
-    </x:scenario>
+  <!-- Subject -->
+  <x:scenario label="Subject is transformed to dcterms:subject">
+    <x:context href="../../fixtures/free_library_test.csv.xml"/>
+    <x:expect label="Subject is transformed to dcterms:subject" test="oai_dc:dc/dcterms:subject = 'Planters (containers) | Pottery | Rosettes | Tulips'"/>
+  </x:scenario>
 
-    <!-- Title -->
-    <x:scenario label="Title is transformed to dcterms:title">
-      <x:context href="../../fixtures/free_library_test.csv.xml"/>
-      <x:expect label="Title is transformed to dcterms:title" test="oai_dc:dc/dcterms:title = 'Birth and Baptismal Certificate (Geburts und Taufschein) for Jonas Laber'"/>
-    </x:scenario>
+  <!-- Title -->
+  <x:scenario label="Title is transformed to dcterms:title">
+    <x:context href="../../fixtures/free_library_test.csv.xml"/>
+    <x:expect label="Title is transformed to dcterms:title" test="oai_dc:dc/dcterms:title = 'Birth and Baptismal Certificate (Geburts und Taufschein) for Jonas Laber'"/>
+  </x:scenario>
 
-    <!-- Type -->
-    <x:scenario label="Type are matched and remediated for known strings">
-      <x:scenario label="Image Type Remediation">
-        <x:scenario label="Image Type Remediation: Starts with lowercase image">
-          <x:context>
-            <record>
-              <Type>Still Image</Type>
-              <Item_No>record-that-should-be-kept</Item_No>
-            </record>
-          </x:context>
-          <x:expect label="Output record Type is 'Still Image'" test="oai_dc:dc/dcterms:type = 'Still Image'" />
-        </x:scenario>
+  <!-- Type -->
+  <x:scenario label="Type are matched and remediated for known strings">
+    <x:scenario label="Image Type Remediation">
+      <x:scenario label="Image Type Remediation: Starts with lowercase image">
+        <x:context>
+          <record>
+            <Type>Still Image</Type>
+            <Item_No>record-that-should-be-kept</Item_No>
+          </record>
+        </x:context>
+        <x:expect label="Output record Type is 'Still Image'" test="oai_dc:dc/dcterms:type = 'Still Image'" />
       </x:scenario>
     </x:scenario>
+  </x:scenario>
 </x:description>

--- a/transforms/free_library_csv.xsl
+++ b/transforms/free_library_csv.xsl
@@ -1,0 +1,274 @@
+<?xml version='1.0' encoding='utf-8'?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:dcterms="http://purl.org/dc/terms/"
+  xmlns:dpla="http://dp.la/about/map/"
+  xmlns:edm="http://www.europeana.eu/schemas/edm/"
+  xmlns:oclcdc="http://worldcat.org/xmlschemas/oclcdc-1.0/"
+  xmlns:padig="http://padigitial.org/ns/"
+  xmlns:oclcterms="http://purl.org/oclc/terms/"
+  xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+  xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+  xmlns:oclc="http://purl.org/oclc/terms/"
+  xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/"
+  xmlns:schema="http://schema.org"
+  xmlns:svcs="http://rdfs.org/sioc/services"
+  version="2.0">
+    <xsl:output omit-xml-declaration="no" method="xml" encoding="UTF-8" indent="yes"/>
+    <xsl:strip-space elements="*"/>
+
+    <!-- Use includes here if you need to separate out templates for either use specific to a dataset or use generic enough for multiple providers (like remediation.xslt). -->
+
+    <!-- For using this XSLT in Combine, you need to replace the following with an actionable HTTP link to the remediation XSLT, or load both XSLT into Combine then rename this to the filepath & name assigned to remediation.xslt within Combine. -->
+
+    <xsl:include href="/home/combine/data/combine/transformations/lookup.xsl"/>
+    <xsl:include href="/home/combine/data/combine/transformations/filter.xsl"/>
+
+    <!-- drop nodes we don't care about (header values, records marked deleted, specific relation fields) -->
+    <xsl:template match="text() | @*"/>
+
+    <!-- base record. Matches each OAI feed record that is mapped. Filters out records with dc:identifier values contained in remediation_filter.xsl -->
+    <xsl:template match="//record">
+        <oai_dc:dc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dpla="http://dp.la/about/map/" xmlns:edm="http://www.europeana.eu/schemas/edm/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:oclc="http://purl.org/oclc/terms/" xmlns:oclcdc="http://worldcat.org/xmlschemas/oclcdc-1.0/" xmlns:oclcterms="http://purl.org/oclc/terms/" xmlns:schema="http://schema.org">
+
+            <!-- will match specific templates that relevant for dplah. -->
+            <xsl:apply-templates/>
+
+            <!-- add templates you have to call - e.g. named templates; matched templates with mode -->
+            <xsl:call-template name="static-rights-statement"/>
+            <xsl:call-template name="intprovider"/>
+            <xsl:call-template name="hub"/>
+        </oai_dc:dc>
+    </xsl:template>
+
+    <!-- FREE LIBRARY-SPECIFIC IDENTITY TEMPLATES -->
+
+    <!-- Collection Name -->
+    <xsl:template match="Collection_Name">
+        <xsl:if test="normalize-space(lower-case(.))">
+          <xsl:element name="dcterms:isPartOf">
+              <xsl:value-of select="normalize-space(.)"/>
+          </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- Creator -->
+    <xsl:template match="Creator">
+        <xsl:if test="normalize-space(.) != ''">
+            <xsl:element name="dcterms:creator">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- Date -->
+    <xsl:template match="Creation_Date">
+        <xsl:if test="normalize-space(.) != ''">
+            <xsl:element name="dcterms:date">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- Description -->
+    <xsl:template match="Description">
+        <xsl:if test="normalize-space(.) != ''">
+            <xsl:element name="dcterms:description">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- Identifier -->
+    <xsl:template match="Item_No">
+        <xsl:if test="normalize-space(.) != ''">
+            <xsl:element name="dcterms:identifier">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- Language -->
+    <xsl:template match="Language">
+        <xsl:if test="normalize-space(.) != ''">
+            <xsl:element name="dcterms:language">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- Subject -->
+    <xsl:template match="Subject">
+        <xsl:call-template name="subj_template">
+            <xsl:with-param name="stringz" select="."/>
+            <xsl:with-param name="delimiter" select="'|'"/>
+        </xsl:call-template>
+    </xsl:template>
+
+    <!-- Title -->
+    <xsl:template match="Title">
+        <xsl:if test="normalize-space(.) != ''">
+            <xsl:element name="dcterms:title">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- Thumbnail URL -->
+    <xsl:template match="Thumbnail">
+        <xsl:if test="normalize-space(.) != ''">
+            <xsl:element name="edm:preview">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- Trackback URL -->
+    <xsl:template match="Identifier">
+        <xsl:if test="normalize-space(.) != ''">
+            <xsl:element name="edm:isShownAt">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- Type -->
+    <xsl:template match="Type">
+        <xsl:if test="normalize-space(.) != ''">
+            <xsl:choose>
+                <xsl:when test="matches(lowercase(.), '(^text.*$)', 'i')">
+                    <dcterms:type>Text</dcterms:type>
+                </xsl:when>
+                <xsl:when test="matches(lowercase(.), '(^image.*$)', 'i')">
+                    <dcterms:type>Image</dcterms:type>
+                </xsl:when>
+                <xsl:when test="matches(lowercase(.), '^(movingimage.*$|moving\simage.*$)', 'i')">
+                    <dcterms:type>Moving Image</dcterms:type>
+                </xsl:when>
+                <xsl:when test="matches(lowercase(.), '^(sound.*$)', 'i')">
+                    <dcterms:type>Sound</dcterms:type>
+                </xsl:when>
+                <xsl:when test="matches(lowercase(.), '^(physicalobject.*$|physical\sobject.*$)', 'i')">
+                    <dcterms:type>Physical Object</dcterms:type>
+                </xsl:when>
+                <xsl:when test="matches(lowercase(.), '^(interactiveresource.*$|interactive\sresource.*$)', 'i')">
+                    <dcterms:type>Interactive Resource</dcterms:type>
+                </xsl:when>
+                <xsl:when test="matches(lowercase(.), '^(stillimage.*$|still\simage.*$)', 'i')">
+                    <dcterms:type>Still Image</dcterms:type>
+                </xsl:when>
+                <!-- Format -->
+                <xsl:otherwise>
+                    <dcterms:format>
+                        <xsl:value-of select="normalize-space(.)"/>
+                    </dcterms:format>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- HISTORIC-PITTSBURGH-SPECIFIC NAMED TEMPLATES -->
+
+    <!-- Intermediate provider -->
+    <xsl:template name="intprovider">
+        <xsl:element name="dpla:intermediateProvider">
+            <xsl:value-of>Free Library of Philadelphia</xsl:value-of>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- Hub -->
+    <xsl:template name="hub">
+        <xsl:element name="edm:provider">
+            <xsl:value-of>PA Digital</xsl:value-of>
+        </xsl:element>
+    </xsl:template>
+
+    <!-- Rights -->
+    <xsl:template name="static-rights-statement">
+      <xsl:element name="dcterms:rights">
+        <xsl:value-of>High-resolution images from the Free Library of Philadelphia's collections are available for publication and other uses, within copyright and licensing restrictions. Please take note of the Item No which you will need to fill out the Reproduction Services form.</xsl:value-of>
+      </xsl:element>
+    </xsl:template>
+
+    <!-- Subject -->
+    <xsl:template name="subj_template">
+        <xsl:param name="stringz"/>
+        <xsl:param name="delimiter"/>
+
+        <xsl:choose>
+            <!-- IF A PAREN, STOP AT AN OPENING semicolon -->
+            <xsl:when test="contains($stringz, $delimiter)">
+                <xsl:variable name="newstem" select="substring-after($stringz, $delimiter)"/>
+                <dcterms:subject>
+                    <xsl:value-of select="substring-before($stringz, $delimiter)"/>
+                </dcterms:subject>
+
+                <!--Need to do recursion-->
+                <xsl:call-template name="subj_template">
+                    <xsl:with-param name="stringz" select="$newstem"/>
+                    <xsl:with-param name="delimiter" select="';'"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <dcterms:subject>
+                    <xsl:value-of select="normalize-space($stringz)"/>
+                </dcterms:subject>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- Type -->
+    <xsl:template name="type_template">
+        <xsl:param name="stringz"/>
+        <xsl:param name="delimiter"/>
+
+        <xsl:choose>
+            <!-- IF A PAREN, STOP AT AN OPENING semicolon -->
+            <xsl:when test="contains($stringz, $delimiter)">
+                <xsl:variable name="newstem" select="substring-after($stringz, $delimiter)"/>
+                <dcterms:type>
+                    <xsl:value-of select="substring-before($stringz, $delimiter)"/>
+                </dcterms:type>
+
+                <!--Need to do recursion-->
+                <xsl:call-template name="type_template">
+                    <xsl:with-param name="stringz" select="$newstem"/>
+                    <xsl:with-param name="delimiter" select="'; '"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <dcterms:type>
+                    <xsl:value-of select="normalize-space($stringz)"/>
+                </dcterms:type>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- Language -->
+    <xsl:template name="lang_template">
+        <xsl:param name="stringz"/>
+        <xsl:param name="delimiter"/>
+
+        <xsl:choose>
+            <!-- IF A PAREN, STOP AT AN OPENING semicolon -->
+            <xsl:when test="contains($stringz, $delimiter)">
+                <xsl:variable name="newstem" select="substring-after($stringz, $delimiter)"/>
+                <dcterms:language>
+                    <xsl:value-of select="substring-before($stringz, $delimiter)"/>
+                </dcterms:language>
+
+                <!--Need to do recursion-->
+                <xsl:call-template name="lang_template">
+                    <xsl:with-param name="stringz" select="$newstem"/>
+                    <xsl:with-param name="delimiter" select="'; '"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <dcterms:language>
+                    <xsl:value-of select="normalize-space($stringz)"/>
+                </dcterms:language>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+</xsl:stylesheet>

--- a/transforms/free_library_csv.xsl
+++ b/transforms/free_library_csv.xsl
@@ -22,8 +22,8 @@
 
     <!-- For using this XSLT in Combine, you need to replace the following with an actionable HTTP link to the remediation XSLT, or load both XSLT into Combine then rename this to the filepath & name assigned to remediation.xslt within Combine. -->
 
-    <xsl:include href="/home/combine/data/combine/transformations/lookup.xsl"/>
-    <xsl:include href="/home/combine/data/combine/transformations/filter.xsl"/>
+    <xsl:include href="remediations/lookup.xsl"/>
+    <xsl:include href="remediations/filter.xsl"/>
 
     <!-- drop nodes we don't care about (header values, records marked deleted, specific relation fields) -->
     <xsl:template match="text() | @*"/>
@@ -137,25 +137,25 @@
     <xsl:template match="Type">
         <xsl:if test="normalize-space(.) != ''">
             <xsl:choose>
-                <xsl:when test="matches(lowercase(.), '(^text.*$)', 'i')">
+                <xsl:when test="matches(lower-case(.), '(^text.*$)', 'i')">
                     <dcterms:type>Text</dcterms:type>
                 </xsl:when>
-                <xsl:when test="matches(lowercase(.), '(^image.*$)', 'i')">
+                <xsl:when test="matches(lower-case(.), '(^image.*$)', 'i')">
                     <dcterms:type>Image</dcterms:type>
                 </xsl:when>
-                <xsl:when test="matches(lowercase(.), '^(movingimage.*$|moving\simage.*$)', 'i')">
+                <xsl:when test="matches(lower-case(.), '^(movingimage.*$|moving\simage.*$)', 'i')">
                     <dcterms:type>Moving Image</dcterms:type>
                 </xsl:when>
-                <xsl:when test="matches(lowercase(.), '^(sound.*$)', 'i')">
+                <xsl:when test="matches(lower-case(.), '^(sound.*$)', 'i')">
                     <dcterms:type>Sound</dcterms:type>
                 </xsl:when>
-                <xsl:when test="matches(lowercase(.), '^(physicalobject.*$|physical\sobject.*$)', 'i')">
+                <xsl:when test="matches(lower-case(.), '^(physicalobject.*$|physical\sobject.*$)', 'i')">
                     <dcterms:type>Physical Object</dcterms:type>
                 </xsl:when>
-                <xsl:when test="matches(lowercase(.), '^(interactiveresource.*$|interactive\sresource.*$)', 'i')">
+                <xsl:when test="matches(lower-case(.), '^(interactiveresource.*$|interactive\sresource.*$)', 'i')">
                     <dcterms:type>Interactive Resource</dcterms:type>
                 </xsl:when>
-                <xsl:when test="matches(lowercase(.), '^(stillimage.*$|still\simage.*$)', 'i')">
+                <xsl:when test="matches(lower-case(.), '^(stillimage.*$|still\simage.*$)', 'i')">
                     <dcterms:type>Still Image</dcterms:type>
                 </xsl:when>
                 <!-- Format -->
@@ -187,7 +187,7 @@
     <!-- Rights -->
     <xsl:template name="static-rights-statement">
       <xsl:element name="dcterms:rights">
-        <xsl:value-of>High-resolution images from the Free Library of Philadelphia's collections are available for publication and other uses, within copyright and licensing restrictions. Please take note of the Item No which you will need to fill out the Reproduction Services form.</xsl:value-of>
+        <xsl:value-of>High-resolution images from the Free Library of Philadelphia&apos;s collections are available for publication and other uses, within copyright and licensing restrictions. Please take note of the Item No which you will need to fill out the Reproduction Services form.</xsl:value-of>
       </xsl:element>
     </xsl:template>
 


### PR DESCRIPTION
What this PR does:
- adds Free Library of Philadelphia dummy XSL for testing CSV exemplar DAG
- adds tests & fixtures for the above