### PR TITLE
fix dplah identifier processing

### DIFF
--- a/fixtures/dplah_test.xml
+++ b/fixtures/dplah_test.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:title>Plan of the skirmish with the rebels</dc:title>
+    <dc:creator>Very Important Creator</dc:creator>
+    <dc:publisher>Very Important Publisher</dc:publisher>
+    <dc:subject>United States - History - Revolution, 1775-1783 - Maps,
+        Manuscript</dc:subject>
+    <dc:subject>United States - History - Revolution, 1775-1783 - Campaigns</dc:subject>
+    <dc:subject>Princess Anne County (Va.) - Maps, Manuscript</dc:subject>
+    <dc:subject>James Plantation (Va.) - Maps, Manuscript</dc:subject>
+    <dc:description>Map showing a skirmish between Hessian and American forces at the James
+        Plantation in Princess Anne County, Virginia during February 1781. (Full caption
+        available at http://library.bloomu.edu/Archives/Maps/maplist.htm ) Published in a 1979
+        English language translation of the diary of a Hessian officer (Ewald, Johann von. Diary
+        of the American War : a Hessian Journal / translated and edited by Joseph P. Tustin. New
+        Haven : Yale University Press, 1979, p. 283) from a 1791 transcription of notes and
+        sketches found in the original diary (Tagebuch von dem Amerikanischen Kriege). The
+        original map includes the page on which it occurs in the 1791
+        transcription.</dc:description>
+    <dc:contributor>Ewald, Johann von, 1744-1813</dc:contributor>
+    <dc:contributor>Bloomsburg University</dc:contributor>
+    <dc:date>1791</dc:date>
+    <dc:date>1791</dc:date>
+    <dc:type>Map</dc:type>
+    <dc:type>Image</dc:type>
+    <dc:format>image/jpeg</dc:format>
+    <dc:identifier>dplapa:BLOOMS_blmmap_34</dc:identifier>
+    <dc:identifier>http://cdm17189.contentdm.oclc.org/cdm/ref/collection/blmmap/id/34</dc:identifier>
+    <dc:identifier>http://cdm17189.contentdm.oclc.org/utils/getthumbnail/collection/blmmap/id/34</dc:identifier>
+    <dc:source>Keystone Library Network</dc:source>
+    <dc:relation>Bloomsburg University Map Collection</dc:relation>
+    <dc:relation>Hi I Am A Finding Aid</dc:relation>
+    <dc:relation>Hi I Am Another Relation</dc:relation>
+    <dc:coverage>United States - Virginia - Princess Anne County ; United States - Viriginia -
+        Princess Anne County - James Plantation</dc:coverage>
+    <dc:rights>Andruss Library digital images and corresponding text may be used for
+        non-commercial, educational, and personal use only without permission, provided that
+        proper attribution of the source accompanies the image. The digital images are not
+        intended for reproduction or redistribution. Commercial publication requires permission.
+        Contact the Bloomsburg University Archives at
+        guides.library.bloomu.edu/universityarchives or (570) 389-4210. Andruss Library assumes
+        no responsibility for infringement of copyright by content users.</dc:rights>
+</oai_dc:dc>

--- a/tests/xslt/dplah.xspec
+++ b/tests/xslt/dplah.xspec
@@ -628,5 +628,57 @@
     <x:expect label="dc:format becomes File Format (schema:fileFormat)"
       test="oai_dc:dc/schema:fileFormat = 'snakes'" />
   </x:scenario>
-
+  
+  <!-- additional DPLAH tests -->
+  
+  <x:scenario label="dc:title and dcterms:alt is mapped">
+    <x:scenario label="dc:title is transformed to dcterms:title">
+      <x:context href="../../fixtures/dplah_test.xml"/>
+      <x:expect label="dc:title is transformed to dcterms:title" test="oai_dc:dc/dcterms:title = 'Plan of the skirmish with the rebels'"/>
+    </x:scenario>
+    <x:scenario label="title not 1 maps to alt title">
+      <x:context>
+        <oai:record>
+          <metadata>
+            <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+              <dc:title>Thing 1</dc:title>
+              <dc:title>Thing 2</dc:title>
+            </oai_dc:dc>
+          </metadata>
+        </oai:record>
+      </x:context>
+      <x:expect label="title not 1 maps to alt title">
+        <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <dcterms:title>Thing 1</dcterms:title>
+          <dcterms:alternative>Thing 2</dcterms:alternative>
+          <edm:provider>PA Digital</edm:provider>
+        </oai_dc:dc>
+      </x:expect>
+    </x:scenario>
+  </x:scenario>
+  
+  <x:scenario label="dc:format is transformed to schema:fileFormat">
+    <x:context href="../../fixtures/dplah_test.xml"/>
+    <x:expect label="dc:format is transformed to schema:fileFormat" test="oai_dc:dc/schema:fileFormat = 'image/jpeg'" />
+  </x:scenario>
+  
+  <x:scenario label="identifier processing">
+    <x:context href="../../fixtures/dplah_test.xml"/>
+    <x:expect label="dc:identifier[1] is transformed to dcterms:identifier" test="oai_dc:dc/dcterms:identifier = 'dplapa:BLOOMS_blmmap_34'" />
+    <x:expect label="dc:identifier[2] is transformed to edm:isShownAt" test="oai_dc:dc/edm:isShownAt = 'http://cdm17189.contentdm.oclc.org/cdm/ref/collection/blmmap/id/34'"/>
+    <x:expect label="dc:identifer (last) is transformed to edm:preview" test="oai_dc:dc/edm:preview = 'http://cdm17189.contentdm.oclc.org/utils/getthumbnail/collection/blmmap/id/34'" />
+  </x:scenario>
+  
+  <x:scenario label="relation processing">
+    <x:context href="../../fixtures/dplah_test.xml"/>
+    <x:expect label="relation[1] is transformed to dcterms:isPartOf" test="oai_dc:dc/dcterms:isPartOf = 'Bloomsburg University Map Collection'"/>
+    <x:expect label="relation[2] is transformed to dcterms:relation" test="oai_dc:dc/dcterms:relation = 'Hi I Am A Finding Aid'" />
+    <x:expect label="relation[3] is transformed to dcterms:relation" test="oai_dc:dc/dcterms:relation = 'Hi I Am Another Relation'" />
+  </x:scenario>
+  
+  <x:scenario label="dc:source[1] is transformed to dpla:intermediateProvider">
+    <x:context href="../../fixtures/dplah_test.xml"/>
+    <x:expect label="dc:source[1] is transformed to dpla:intermediateProvider" test="oai_dc:dc/dpla:intermediateProvider = 'Keystone Library Network'" />
+  </x:scenario>
+  
 </x:description>

--- a/transforms/dplah.xsl
+++ b/transforms/dplah.xsl
@@ -21,8 +21,8 @@
 
     <!-- Use includes here if you need to separate out templates for either use specific to a dataset or use generic enough for multiple providers (like remediation.xslt). -->
     <!-- For using this XSLT in Combine, you need to replace the following with an actionable HTTP link to the remediation XSLT, or load both XSLT into Combine then rename this to the filepath & name assigned to remediation.xslt within Combine. -->
-    <xsl:include href="https://raw.githubusercontent.com/tulibraries/aggregator_mdx/master/transforms/temple.xsl"/>
-    <xsl:include href="https://raw.githubusercontent.com/tulibraries/aggregator_mdx/master/transforms/remediations/filter.xsl"/>
+    <xsl:include href="temple.xsl"/>
+    <xsl:include href="remediations/filter.xsl"/>
 
      <!-- drop nodes we don't care about, namely, header values -->
     <xsl:template match="text() | @*"/>
@@ -137,7 +137,7 @@
         </xsl:if>
     </xsl:template>
 
-    <!-- URL
+    <!-- URL -->
     <xsl:template match="dc:identifier[2]">
         <xsl:if test="normalize-space(.)!=''">
             <xsl:element name="edm:isShownAt">
@@ -146,7 +146,7 @@
         </xsl:if>
     </xsl:template>
 
-    <!- Preview
+    <!-- Preview -->
     <xsl:template match="dc:identifier[position() = last() and position() > 2]">
         <xsl:if test="normalize-space(.)!=''">
             <xsl:element name="edm:preview">
@@ -154,5 +154,5 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
-    -->
+    
 </xsl:stylesheet>


### PR DESCRIPTION
What this PR does:
1. un-comment out the identifier processing in dplah.xsl. (This was fixed in Combine for September harvest but hadn't been updated in repo. Missing trackback URLs are causing all records in DPLAH to fail validation.)
2. update dplah.xspec to test all the transforms in dplah.xsl. (Note that further work is needed to untangle and test for the transforms included in temple.xsl.)
3. add fixture to support dplah.xspec tests.