### PR TITLE
add post-harvest QDC validation

### DIFF
--- a/fixtures/schematron/invalid_empty_qdc_rights1.xml
+++ b/fixtures/schematron/invalid_empty_qdc_rights1.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_qdc:qualifieddc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:dc="http://purl.org/dc/elements/1.1/" 
+    xmlns:dcterms="http://purl.org/dc/terms/" 
+    xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" 
+    xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ 
+    http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd 
+    http://purl.org/net/oclcterms 
+    http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+    <dc:title>Ellen Bayne</dc:title>
+    <dcterms:alternative>Foster's melodies</dcterms:alternative>
+    <dc:date>1854</dc:date>
+    <dc:creator>Foster, Stephen Collins, 1826-1864 [composer]</dc:creator>
+    <dc:creator>Sarony &amp; Co. [lithographer]; Lawson [engraver]</dc:creator>
+    <dc:contributor>Christy, Edwin Pearce, 1815-1862 [performer]</dc:contributor>
+    <dc:publisher>New York : Firth, Pond &amp; Co.</dc:publisher>
+    <dc:subject>Songs with piano; Vocal duets with piano; Popular music--United States--To 1901</dc:subject>
+    <dc:description>Title and floral designs with five insets : girl with hat in landscape garden with fountain, dog laying in front of dog house on farm, farm house in woods, girl with hat in garden, old couple at fireplace with cat.</dc:description>
+    <dc:description>"No. 24". Publisher's no. 2664. Advertisements on cover for "No. 12 : Old dog tray", "No. 20 : My old Kentucky home", "No. 23 : Little Ella" and "No. 22 : Old memories".</dc:description>
+    <dc:format>image/jp2</dc:format>
+    <dc:type>Sheet music</dc:type>
+    <dcterms:extent>score (5 p.) ; 35 cm.</dcterms:extent>
+    <dc:language>English</dc:language>
+    <dc:rights></dc:rights>
+    <dcterms:isPartOf>Temple Sheet Music Collections</dcterms:isPartOf>
+    <dc:identifier>SM00158</dc:identifier>
+    <dc:identifier>http://digital.library.temple.edu/cdm/ref/collection/p15037coll1/id/1137</dc:identifier>
+</oai_qdc:qualifieddc>

--- a/fixtures/schematron/invalid_empty_qdc_rights2.xml
+++ b/fixtures/schematron/invalid_empty_qdc_rights2.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_qdc:qualifieddc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:dc="http://purl.org/dc/elements/1.1/" 
+    xmlns:dcterms="http://purl.org/dc/terms/" 
+    xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" 
+    xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ 
+    http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd 
+    http://purl.org/net/oclcterms 
+    http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+    <dc:title>Ellen Bayne</dc:title>
+    <dcterms:alternative>Foster's melodies</dcterms:alternative>
+    <dc:date>1854</dc:date>
+    <dc:creator>Foster, Stephen Collins, 1826-1864 [composer]</dc:creator>
+    <dc:creator>Sarony &amp; Co. [lithographer]; Lawson [engraver]</dc:creator>
+    <dc:contributor>Christy, Edwin Pearce, 1815-1862 [performer]</dc:contributor>
+    <dc:publisher>New York : Firth, Pond &amp; Co.</dc:publisher>
+    <dc:subject>Songs with piano; Vocal duets with piano; Popular music--United States--To 1901</dc:subject>
+    <dc:description>Title and floral designs with five insets : girl with hat in landscape garden with fountain, dog laying in front of dog house on farm, farm house in woods, girl with hat in garden, old couple at fireplace with cat.</dc:description>
+    <dc:description>"No. 24". Publisher's no. 2664. Advertisements on cover for "No. 12 : Old dog tray", "No. 20 : My old Kentucky home", "No. 23 : Little Ella" and "No. 22 : Old memories".</dc:description>
+    <dc:format>image/jp2</dc:format>
+    <dc:type>Sheet music</dc:type>
+    <dcterms:extent>score (5 p.) ; 35 cm.</dcterms:extent>
+    <dc:language>English</dc:language>
+    <dc:rights/>
+    <dcterms:isPartOf>Temple Sheet Music Collections</dcterms:isPartOf>
+    <dc:identifier>SM00158</dc:identifier>
+    <dc:identifier>http://digital.library.temple.edu/cdm/ref/collection/p15037coll1/id/1137</dc:identifier>
+</oai_qdc:qualifieddc>

--- a/fixtures/schematron/invalid_empty_qdc_title1.xml
+++ b/fixtures/schematron/invalid_empty_qdc_title1.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_qdc:qualifieddc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:dc="http://purl.org/dc/elements/1.1/" 
+    xmlns:dcterms="http://purl.org/dc/terms/" 
+    xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" 
+    xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ 
+    http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd 
+    http://purl.org/net/oclcterms 
+    http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+    <dc:title/>
+    <dcterms:alternative>Foster's melodies</dcterms:alternative>
+    <dc:date>1854</dc:date>
+    <dc:creator>Foster, Stephen Collins, 1826-1864 [composer]</dc:creator>
+    <dc:creator>Sarony &amp; Co. [lithographer]; Lawson [engraver]</dc:creator>
+    <dc:contributor>Christy, Edwin Pearce, 1815-1862 [performer]</dc:contributor>
+    <dc:publisher>New York : Firth, Pond &amp; Co.</dc:publisher>
+    <dc:subject>Songs with piano; Vocal duets with piano; Popular music--United States--To 1901</dc:subject>
+    <dc:description>Title and floral designs with five insets : girl with hat in landscape garden with fountain, dog laying in front of dog house on farm, farm house in woods, girl with hat in garden, old couple at fireplace with cat.</dc:description>
+    <dc:description>"No. 24". Publisher's no. 2664. Advertisements on cover for "No. 12 : Old dog tray", "No. 20 : My old Kentucky home", "No. 23 : Little Ella" and "No. 22 : Old memories".</dc:description>
+    <dc:format>image/jp2</dc:format>
+    <dc:type>Sheet music</dc:type>
+    <dcterms:extent>score (5 p.) ; 35 cm.</dcterms:extent>
+    <dc:language>English</dc:language>
+    <dc:rights>This material is subject to copyright law and is made available for private study, scholarship, and research purposes only. For access to the original or a high resolution reproduction, and for permission to publish, please contact Temple University Libraries, Special Collections Research Center, scrc@temple.edu, 215-204-8257. </dc:rights>
+    <dcterms:isPartOf>Temple Sheet Music Collections</dcterms:isPartOf>
+    <dc:identifier>SM00158</dc:identifier>
+    <dc:identifier>http://digital.library.temple.edu/cdm/ref/collection/p15037coll1/id/1137</dc:identifier>
+</oai_qdc:qualifieddc>

--- a/fixtures/schematron/invalid_empty_qdc_title2.xml
+++ b/fixtures/schematron/invalid_empty_qdc_title2.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_qdc:qualifieddc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:dc="http://purl.org/dc/elements/1.1/" 
+    xmlns:dcterms="http://purl.org/dc/terms/" 
+    xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" 
+    xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ 
+    http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd 
+    http://purl.org/net/oclcterms 
+    http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+    <dc:title></dc:title>
+    <dcterms:alternative>Foster's melodies</dcterms:alternative>
+    <dc:date>1854</dc:date>
+    <dc:creator>Foster, Stephen Collins, 1826-1864 [composer]</dc:creator>
+    <dc:creator>Sarony &amp; Co. [lithographer]; Lawson [engraver]</dc:creator>
+    <dc:contributor>Christy, Edwin Pearce, 1815-1862 [performer]</dc:contributor>
+    <dc:publisher>New York : Firth, Pond &amp; Co.</dc:publisher>
+    <dc:subject>Songs with piano; Vocal duets with piano; Popular music--United States--To 1901</dc:subject>
+    <dc:description>Title and floral designs with five insets : girl with hat in landscape garden with fountain, dog laying in front of dog house on farm, farm house in woods, girl with hat in garden, old couple at fireplace with cat.</dc:description>
+    <dc:description>"No. 24". Publisher's no. 2664. Advertisements on cover for "No. 12 : Old dog tray", "No. 20 : My old Kentucky home", "No. 23 : Little Ella" and "No. 22 : Old memories".</dc:description>
+    <dc:format>image/jp2</dc:format>
+    <dc:type>Sheet music</dc:type>
+    <dcterms:extent>score (5 p.) ; 35 cm.</dcterms:extent>
+    <dc:language>English</dc:language>
+    <dc:rights>This material is subject to copyright law and is made available for private study, scholarship, and research purposes only. For access to the original or a high resolution reproduction, and for permission to publish, please contact Temple University Libraries, Special Collections Research Center, scrc@temple.edu, 215-204-8257. </dc:rights>
+    <dcterms:isPartOf>Temple Sheet Music Collections</dcterms:isPartOf>
+    <dc:identifier>SM00158</dc:identifier>
+    <dc:identifier>http://digital.library.temple.edu/cdm/ref/collection/p15037coll1/id/1137</dc:identifier>
+</oai_qdc:qualifieddc>

--- a/fixtures/schematron/invalid_missing_qdc_multiple.xml
+++ b/fixtures/schematron/invalid_missing_qdc_multiple.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_qdc:qualifieddc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:dc="http://purl.org/dc/elements/1.1/" 
+    xmlns:dcterms="http://purl.org/dc/terms/" 
+    xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" 
+    xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ 
+    http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd 
+    http://purl.org/net/oclcterms 
+    http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+    <dcterms:alternative>Foster's melodies</dcterms:alternative>
+    <dc:date>1854</dc:date>
+    <dc:creator>Foster, Stephen Collins, 1826-1864 [composer]</dc:creator>
+    <dc:creator>Sarony &amp; Co. [lithographer]; Lawson [engraver]</dc:creator>
+    <dc:contributor>Christy, Edwin Pearce, 1815-1862 [performer]</dc:contributor>
+    <dc:publisher>New York : Firth, Pond &amp; Co.</dc:publisher>
+    <dc:subject>Songs with piano; Vocal duets with piano; Popular music--United States--To 1901</dc:subject>
+    <dc:description>Title and floral designs with five insets : girl with hat in landscape garden with fountain, dog laying in front of dog house on farm, farm house in woods, girl with hat in garden, old couple at fireplace with cat.</dc:description>
+    <dc:description>"No. 24". Publisher's no. 2664. Advertisements on cover for "No. 12 : Old dog tray", "No. 20 : My old Kentucky home", "No. 23 : Little Ella" and "No. 22 : Old memories".</dc:description>
+    <dc:format>image/jp2</dc:format>
+    <dc:type>Sheet music</dc:type>
+    <dcterms:extent>score (5 p.) ; 35 cm.</dcterms:extent>
+    <dc:language>English</dc:language>
+    <dcterms:isPartOf>Temple Sheet Music Collections</dcterms:isPartOf>
+    <dc:identifier>SM00158</dc:identifier>
+    <dc:identifier>http://digital.library.temple.edu/cdm/ref/collection/p15037coll1/id/1137</dc:identifier>
+</oai_qdc:qualifieddc>

--- a/fixtures/schematron/invalid_missing_qdc_rights.xml
+++ b/fixtures/schematron/invalid_missing_qdc_rights.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_qdc:qualifieddc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:dc="http://purl.org/dc/elements/1.1/" 
+    xmlns:dcterms="http://purl.org/dc/terms/" 
+    xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" 
+    xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ 
+    http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd 
+    http://purl.org/net/oclcterms 
+    http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+    <dc:title>Ellen Bayne</dc:title>
+    <dcterms:alternative>Foster's melodies</dcterms:alternative>
+    <dc:date>1854</dc:date>
+    <dc:creator>Foster, Stephen Collins, 1826-1864 [composer]</dc:creator>
+    <dc:creator>Sarony &amp; Co. [lithographer]; Lawson [engraver]</dc:creator>
+    <dc:contributor>Christy, Edwin Pearce, 1815-1862 [performer]</dc:contributor>
+    <dc:publisher>New York : Firth, Pond &amp; Co.</dc:publisher>
+    <dc:subject>Songs with piano; Vocal duets with piano; Popular music--United States--To 1901</dc:subject>
+    <dc:description>Title and floral designs with five insets : girl with hat in landscape garden with fountain, dog laying in front of dog house on farm, farm house in woods, girl with hat in garden, old couple at fireplace with cat.</dc:description>
+    <dc:description>"No. 24". Publisher's no. 2664. Advertisements on cover for "No. 12 : Old dog tray", "No. 20 : My old Kentucky home", "No. 23 : Little Ella" and "No. 22 : Old memories".</dc:description>
+    <dc:format>image/jp2</dc:format>
+    <dc:type>Sheet music</dc:type>
+    <dcterms:extent>score (5 p.) ; 35 cm.</dcterms:extent>
+    <dc:language>English</dc:language>
+    <dcterms:isPartOf>Temple Sheet Music Collections</dcterms:isPartOf>
+    <dc:identifier>SM00158</dc:identifier>
+    <dc:identifier>http://digital.library.temple.edu/cdm/ref/collection/p15037coll1/id/1137</dc:identifier>
+</oai_qdc:qualifieddc>

--- a/fixtures/schematron/invalid_missing_qdc_title.xml
+++ b/fixtures/schematron/invalid_missing_qdc_title.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_qdc:qualifieddc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:dc="http://purl.org/dc/elements/1.1/" 
+    xmlns:dcterms="http://purl.org/dc/terms/" 
+    xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" 
+    xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ 
+    http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd 
+    http://purl.org/net/oclcterms 
+    http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+    <dcterms:alternative>Foster's melodies</dcterms:alternative>
+    <dc:date>1854</dc:date>
+    <dc:creator>Foster, Stephen Collins, 1826-1864 [composer]</dc:creator>
+    <dc:creator>Sarony &amp; Co. [lithographer]; Lawson [engraver]</dc:creator>
+    <dc:contributor>Christy, Edwin Pearce, 1815-1862 [performer]</dc:contributor>
+    <dc:publisher>New York : Firth, Pond &amp; Co.</dc:publisher>
+    <dc:subject>Songs with piano; Vocal duets with piano; Popular music--United States--To 1901</dc:subject>
+    <dc:description>Title and floral designs with five insets : girl with hat in landscape garden with fountain, dog laying in front of dog house on farm, farm house in woods, girl with hat in garden, old couple at fireplace with cat.</dc:description>
+    <dc:description>"No. 24". Publisher's no. 2664. Advertisements on cover for "No. 12 : Old dog tray", "No. 20 : My old Kentucky home", "No. 23 : Little Ella" and "No. 22 : Old memories".</dc:description>
+    <dc:format>image/jp2</dc:format>
+    <dc:type>Sheet music</dc:type>
+    <dcterms:extent>score (5 p.) ; 35 cm.</dcterms:extent>
+    <dc:language>English</dc:language>
+    <dc:rights>This material is subject to copyright law and is made available for private study, scholarship, and research purposes only. For access to the original or a high resolution reproduction, and for permission to publish, please contact Temple University Libraries, Special Collections Research Center, scrc@temple.edu, 215-204-8257. </dc:rights>
+    <dcterms:isPartOf>Temple Sheet Music Collections</dcterms:isPartOf>
+    <dc:identifier>SM00158</dc:identifier>
+    <dc:identifier>http://digital.library.temple.edu/cdm/ref/collection/p15037coll1/id/1137</dc:identifier>
+</oai_qdc:qualifieddc>

--- a/fixtures/schematron/invalid_qdc_RelNoHarvest.xml
+++ b/fixtures/schematron/invalid_qdc_RelNoHarvest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_qdc:qualifieddc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:dc="http://purl.org/dc/elements/1.1/" 
+    xmlns:dcterms="http://purl.org/dc/terms/" 
+    xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" 
+    xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ 
+    http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd 
+    http://purl.org/net/oclcterms 
+    http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+    <dc:title>Ellen Bayne</dc:title>
+    <dcterms:alternative>Foster's melodies</dcterms:alternative>
+    <dc:date>1854</dc:date>
+    <dc:creator>Foster, Stephen Collins, 1826-1864 [composer]</dc:creator>
+    <dc:creator>Sarony &amp; Co. [lithographer]; Lawson [engraver]</dc:creator>
+    <dc:contributor>Christy, Edwin Pearce, 1815-1862 [performer]</dc:contributor>
+    <dc:publisher>New York : Firth, Pond &amp; Co.</dc:publisher>
+    <dc:subject>Songs with piano; Vocal duets with piano; Popular music--United States--To 1901</dc:subject>
+    <dc:description>Title and floral designs with five insets : girl with hat in landscape garden with fountain, dog laying in front of dog house on farm, farm house in woods, girl with hat in garden, old couple at fireplace with cat.</dc:description>
+    <dc:description>"No. 24". Publisher's no. 2664. Advertisements on cover for "No. 12 : Old dog tray", "No. 20 : My old Kentucky home", "No. 23 : Little Ella" and "No. 22 : Old memories".</dc:description>
+    <dc:format>image/jp2</dc:format>
+    <dc:type>Sheet music</dc:type>
+    <dcterms:extent>score (5 p.) ; 35 cm.</dcterms:extent>
+    <dc:language>English</dc:language>
+    <dc:rights>This material is subject to copyright law and is made available for private study, scholarship, and research purposes only. For access to the original or a high resolution reproduction, and for permission to publish, please contact Temple University Libraries, Special Collections Research Center, scrc@temple.edu, 215-204-8257. </dc:rights>
+    <dcterms:isPartOf>Temple Sheet Music Collections</dcterms:isPartOf>
+    <dc:relation>pdcp_noharvest</dc:relation>
+    <dc:identifier>SM00158</dc:identifier>
+    <dc:identifier>http://digital.library.temple.edu/cdm/ref/collection/p15037coll1/id/1137</dc:identifier>
+</oai_qdc:qualifieddc>

--- a/fixtures/schematron/invalid_qdc_RightsNoHarvest.xml
+++ b/fixtures/schematron/invalid_qdc_RightsNoHarvest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_qdc:qualifieddc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:dc="http://purl.org/dc/elements/1.1/" 
+    xmlns:dcterms="http://purl.org/dc/terms/" 
+    xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" 
+    xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ 
+    http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd 
+    http://purl.org/net/oclcterms 
+    http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+    <dc:title>Ellen Bayne</dc:title>
+    <dcterms:alternative>Foster's melodies</dcterms:alternative>
+    <dc:date>1854</dc:date>
+    <dc:creator>Foster, Stephen Collins, 1826-1864 [composer]</dc:creator>
+    <dc:creator>Sarony &amp; Co. [lithographer]; Lawson [engraver]</dc:creator>
+    <dc:contributor>Christy, Edwin Pearce, 1815-1862 [performer]</dc:contributor>
+    <dc:publisher>New York : Firth, Pond &amp; Co.</dc:publisher>
+    <dc:subject>Songs with piano; Vocal duets with piano; Popular music--United States--To 1901</dc:subject>
+    <dc:description>Title and floral designs with five insets : girl with hat in landscape garden with fountain, dog laying in front of dog house on farm, farm house in woods, girl with hat in garden, old couple at fireplace with cat.</dc:description>
+    <dc:description>"No. 24". Publisher's no. 2664. Advertisements on cover for "No. 12 : Old dog tray", "No. 20 : My old Kentucky home", "No. 23 : Little Ella" and "No. 22 : Old memories".</dc:description>
+    <dc:format>image/jp2</dc:format>
+    <dc:type>Sheet music</dc:type>
+    <dcterms:extent>score (5 p.) ; 35 cm.</dcterms:extent>
+    <dc:language>English</dc:language>
+    <dc:rights>This material is subject to copyright law and is made available for private study, scholarship, and research purposes only. For access to the original or a high resolution reproduction, and for permission to publish, please contact Temple University Libraries, Special Collections Research Center, scrc@temple.edu, 215-204-8257. </dc:rights>
+    <dc:rights>pdcp_noharvest</dc:rights>
+    <dcterms:isPartOf>Temple Sheet Music Collections</dcterms:isPartOf>
+    <dc:identifier>SM00158</dc:identifier>
+    <dc:identifier>http://digital.library.temple.edu/cdm/ref/collection/p15037coll1/id/1137</dc:identifier>
+</oai_qdc:qualifieddc>

--- a/fixtures/schematron/valid_qdc.xml
+++ b/fixtures/schematron/valid_qdc.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<oai_qdc:qualifieddc xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:dc="http://purl.org/dc/elements/1.1/" 
+    xmlns:dcterms="http://purl.org/dc/terms/" 
+    xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" 
+    xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ 
+    http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd 
+    http://purl.org/net/oclcterms 
+    http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+    <dc:title>Ellen Bayne</dc:title>
+    <dcterms:alternative>Foster's melodies</dcterms:alternative>
+    <dc:date>1854</dc:date>
+    <dc:creator>Foster, Stephen Collins, 1826-1864 [composer]</dc:creator>
+    <dc:creator>Sarony &amp; Co. [lithographer]; Lawson [engraver]</dc:creator>
+    <dc:contributor>Christy, Edwin Pearce, 1815-1862 [performer]</dc:contributor>
+    <dc:publisher>New York : Firth, Pond &amp; Co.</dc:publisher>
+    <dc:subject>Songs with piano; Vocal duets with piano; Popular music--United States--To 1901</dc:subject>
+    <dc:description>Title and floral designs with five insets : girl with hat in landscape garden with fountain, dog laying in front of dog house on farm, farm house in woods, girl with hat in garden, old couple at fireplace with cat.</dc:description>
+    <dc:description>"No. 24". Publisher's no. 2664. Advertisements on cover for "No. 12 : Old dog tray", "No. 20 : My old Kentucky home", "No. 23 : Little Ella" and "No. 22 : Old memories".</dc:description>
+    <dc:format>image/jp2</dc:format>
+    <dc:type>Sheet music</dc:type>
+    <dcterms:extent>score (5 p.) ; 35 cm.</dcterms:extent>
+    <dc:language>English</dc:language>
+    <dc:rights>This material is subject to copyright law and is made available for private study, scholarship, and research purposes only. For access to the original or a high resolution reproduction, and for permission to publish, please contact Temple University Libraries, Special Collections Research Center, scrc@temple.edu, 215-204-8257. </dc:rights>
+    <dcterms:isPartOf>Temple Sheet Music Collections</dcterms:isPartOf>
+    <dc:identifier>SM00158</dc:identifier>
+    <dc:identifier>http://digital.library.temple.edu/cdm/ref/collection/p15037coll1/id/1137</dc:identifier>
+</oai_qdc:qualifieddc>

--- a/tests/schematron/qdcingest_reqd_fields.xspec
+++ b/tests/schematron/qdcingest_reqd_fields.xspec
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+  schematron="../../validations/qdcingest_reqd_fields.sch">
+  <x:scenario label="RequiredElementsPattern">
+    <x:scenario label="valid: dc:title">
+      <x:context href="../../fixtures/schematron/valid_qdc.xml"/>
+      <x:expect-valid/>
+    </x:scenario>
+    <x:scenario label="not valid: missing title">
+      <x:context href="../../fixtures/schematron/invalid_missing_qdc_title.xml"/>
+      <x:expect-assert id="Required1"/>
+    </x:scenario>
+    <x:scenario label="valid: dc:rights>">
+      <x:context href="../../fixtures/schematron/valid_qdc.xml"/>
+      <x:expect-valid/>
+    </x:scenario>
+    <x:scenario label="not valid: missing rights">
+      <x:context href="../../fixtures/schematron/invalid_missing_qdc_rights.xml"/>
+      <x:expect-assert id="Required2"/>
+    </x:scenario>
+    <x:scenario label="not valid: missing multiple">
+      <x:context href="../../fixtures/schematron/invalid_missing_qdc_multiple.xml"/>
+      <x:expect-assert id="Required1"/>
+      <x:expect-assert id="Required2"/>
+    </x:scenario>
+  </x:scenario>
+  <x:scenario label="TitleElementPattern">
+    <x:scenario label="valid">
+      <x:context href="../../fixtures/schematron/valid_qdc.xml"/>
+      <x:expect-valid/>
+    </x:scenario>
+    <x:scenario label="not valid">
+      <x:scenario label="not valid: empty title 1">
+        <x:context href="../../fixtures/schematron/invalid_empty_qdc_title1.xml"/>
+        <x:expect-assert id="Title1"/>
+      </x:scenario>
+      <x:scenario label="not valid: empty title 2">
+        <x:context href="../../fixtures/schematron/invalid_empty_qdc_title2.xml"/>
+        <x:expect-assert id="Title1"/>
+      </x:scenario>
+    </x:scenario>
+  </x:scenario>
+  <x:scenario label="RightsElementPattern">
+    <x:scenario label="valid">
+      <x:context href="../../fixtures/schematron/valid_qdc.xml"/>
+      <x:expect-valid/>
+    </x:scenario>
+    <x:scenario label="not valid">
+      <x:scenario label="not valid: empty rights 1">
+        <x:context href="../../fixtures/schematron/invalid_empty_qdc_rights1.xml"/>
+        <x:expect-assert id="Rights1"/>
+      </x:scenario>
+      <x:scenario label="not valid: empty rights 2">
+        <x:context href="../../fixtures/schematron/invalid_empty_qdc_rights2.xml"/>
+        <x:expect-assert id="Rights1"/>
+      </x:scenario>
+    </x:scenario>
+  </x:scenario>
+  <x:scenario label="RelNoHarvest">
+    <x:scenario label="valid">
+      <x:context href="../../fixtures/schematron/valid_qdc.xml"/>
+      <x:expect-valid/>
+    </x:scenario>
+    <x:scenario label="not valid">
+      <x:context href="../../fixtures/schematron/invalid_qdc_RelNoHarvest.xml"/>
+      <x:expect-assert id="RelNoHarvest1"/>
+    </x:scenario>
+  </x:scenario>
+  <x:scenario label="RightsNoHarvest">
+    <x:scenario label="valid">
+      <x:context href="../../fixtures/schematron/valid_qdc.xml"/>
+      <x:expect-valid/>
+    </x:scenario>
+    <x:scenario label="not valid">
+      <x:context href="../../fixtures/schematron/invalid_qdc_RightsNoHarvest.xml"/>
+      <x:expect-assert id="RightsNoHarvest1"/>
+    </x:scenario>
+  </x:scenario>
+</x:description>

--- a/validations/qdcingest_reqd_fields.sch
+++ b/validations/qdcingest_reqd_fields.sch
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" 
+  xmlns:dcterms="http://purl.org/dc/terms/"
+  xmlns:dc="http://purl.org/dc/elements/1.1/" 
+  xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/"
+  xmlns:edm="http://www.europeana.eu/schemas/edm/"
+  xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+  <ns prefix="dcterms" uri="http://purl.org/dc/terms/"/>
+  <ns prefix="dc" uri="http://purl.org/dc/elements/1.1/"/>
+  <ns prefix="edm" uri="http://www.europeana.eu/schemas/edm/"/>
+  <ns prefix="oai_dc" uri="http://www.openarchives.org/OAI/2.0/oai_dc/"/>
+  <ns prefix="oai_qdc" uri="http://worldcat.org/xmlschemas/qdc-1.0/"/>
+
+  <pattern id="RequiredElementsPattern">
+    <title>DPLAH fields required</title>
+    <rule context="oai_qdc:qualifieddc">
+      <assert test="dc:title" id="Required1" role="error">There must be a title</assert>
+      <assert test="dc:rights" id="Required2" role="error">There must be a rights statement</assert>
+    </rule>
+  </pattern>
+  <pattern id="TitleElementPattern">
+    <title>Required fields must contain text.</title>
+    <rule context="oai_qdc:qualifieddc/dc:title">
+      <assert test="normalize-space(.)" id="Title1" role="error">The title property must contain
+        text</assert>
+    </rule>
+  </pattern>
+  <pattern id="RightsElementPattern">
+    <rule context="oai_qdc:qualifieddc/dc:rights">
+      <assert test="normalize-space(.)" id="Rights1" role="error">The rights property must contain
+        text</assert>
+    </rule>
+  </pattern>
+  <pattern id="RelNoHarvest">
+    <title>Additional Metadata Requirements</title>
+    <rule context="oai_qdc:qualifieddc/dc:relation">
+      <assert test="normalize-space(.) != 'pdcp_noharvest'" id="RelNoHarvest1" role="error">The
+        relation element must not contain stopword</assert>
+    </rule>
+  </pattern>
+  <pattern id="RightsNoHarvest">
+    <title>Additional Metadata Requirements</title>
+    <rule context="oai_qdc:qualifieddc/dc:rights">
+      <assert test="normalize-space(.) != 'pdcp_noharvest'" id="RightsNoHarvest1" role="error">The
+        rights element must not contain stopword</assert>
+    </rule>
+  </pattern>
+</schema>


### PR DESCRIPTION
What this PR does:
- adds schematron for QDC ingest post-harvest validation
- adds associated xspec for schematron
- adds associated fixtures used by xspec tests