### PR TITLE
add post-harvest validation for CSV-XML

### DIFF
--- a/.docker/saxon/Dockerfile
+++ b/.docker/saxon/Dockerfile
@@ -5,7 +5,7 @@ ENV SAXON_VERSION 9.9.1-5
 ENV SAXON_DOWNLOAD_SHA1 c1f413a1b810dbf0d673ffd3b27c8829a82ac31c
 ENV SAXON_CP /saxon/saxon9he.jar
 RUN mkdir -p /saxon && \
-	curl -fSL -o ${SAXON_CP} http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar && \
+	curl -fSL -o ${SAXON_CP} https://repo1.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar && \
 	echo ${SAXON_DOWNLOAD_SHA1} ${SAXON_CP} | sha1sum -c - && \
 	chmod +x ${SAXON_CP}
 

--- a/.docker/test/Dockerfile
+++ b/.docker/test/Dockerfile
@@ -5,7 +5,7 @@ ENV SAXON_VERSION 9.9.1-5
 ENV SAXON_DOWNLOAD_SHA1 c1f413a1b810dbf0d673ffd3b27c8829a82ac31c
 ENV SAXON_CP /saxon/saxon9he.jar
 RUN mkdir -p /saxon && \
-	curl -fSL -o ${SAXON_CP} http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar && \
+	curl -fSL -o ${SAXON_CP} https://repo1.maven.org/maven2/net/sf/saxon/Saxon-HE/${SAXON_VERSION}/Saxon-HE-${SAXON_VERSION}.jar && \
 	echo ${SAXON_DOWNLOAD_SHA1} ${SAXON_CP} | sha1sum -c - && \
 	chmod +x ${SAXON_CP}
 

--- a/tests/schematron/csv_reqd_fields.xspec
+++ b/tests/schematron/csv_reqd_fields.xspec
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    schematron="../../validations/csv_reqd_fields.sch">
+    
+    <x:scenario label="RequiredElementsPattern">
+        <x:scenario label="valid: title">
+            <x:context>
+                <record airflow-record-id="1">
+                    <Item_No>frk00001</Item_No>
+                    <Title>Birth and Baptismal Certificate (Geburts und Taufschein) for Jonas Laber</Title>
+                    <Creator>Anonymous</Creator>
+                    <Description>Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.</Description>
+                    <Creation_Date>ca. 1825</Creation_Date>
+                    <Format>tif</Format>
+                    <Subject> Flowers | Planters (containers) | Pottery | Rosettes | Tulips</Subject>
+                    <Language>German; English</Language>
+                    <Identifier>http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001</Identifier>
+                    <Thumbnail>http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg</Thumbnail>
+                    <Type>Still Image</Type>
+                    <Collection_Name>Fraktur</Collection_Name>
+                </record>
+            </x:context>
+            <x:expect-valid/>
+        </x:scenario>
+        <x:scenario label="not valid: missing title">
+            <x:context>
+                <record airflow-record-id="1">
+                    <Item_No>frk00001</Item_No>
+                    <Creator>Anonymous</Creator>
+                    <Description>Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.</Description>
+                    <Creation_Date>ca. 1825</Creation_Date>
+                    <Format>tif</Format>
+                    <Subject> Flowers | Planters (containers) | Pottery | Rosettes | Tulips</Subject>
+                    <Language>German; English</Language>
+                    <Identifier>http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001</Identifier>
+                    <Thumbnail>http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg</Thumbnail>
+                    <Type>Still Image</Type>
+                    <Collection_Name>Fraktur</Collection_Name>
+                </record>
+            </x:context>
+            <x:expect-assert id="Required1"/>
+        </x:scenario>        
+    </x:scenario>
+    
+    <x:scenario label="TitleElementPattern">
+        <x:scenario label="valid">
+            <x:context>
+                <record airflow-record-id="1">
+                    <Item_No>frk00001</Item_No>
+                    <Title>Birth and Baptismal Certificate (Geburts und Taufschein) for Jonas Laber</Title>
+                    <Creator>Anonymous</Creator>
+                    <Description>Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.</Description>
+                    <Creation_Date>ca. 1825</Creation_Date>
+                    <Format>tif</Format>
+                    <Subject> Flowers | Planters (containers) | Pottery | Rosettes | Tulips</Subject>
+                    <Language>German; English</Language>
+                    <Identifier>http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001</Identifier>
+                    <Thumbnail>http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg</Thumbnail>
+                    <Type>Still Image</Type>
+                    <Collection_Name>Fraktur</Collection_Name>
+                </record>
+            </x:context>
+            <x:expect-valid/>
+        </x:scenario>
+        <x:scenario label="invalid: empty title 1">
+            <x:context>
+                <record airflow-record-id="1">
+                    <Item_No>frk00001</Item_No>
+                    <Title></Title>
+                    <Creator>Anonymous</Creator>
+                    <Description>Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.</Description>
+                    <Creation_Date>ca. 1825</Creation_Date>
+                    <Format>tif</Format>
+                    <Subject> Flowers | Planters (containers) | Pottery | Rosettes | Tulips</Subject>
+                    <Language>German; English</Language>
+                    <Identifier>http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001</Identifier>
+                    <Thumbnail>http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg</Thumbnail>
+                    <Type>Still Image</Type>
+                    <Collection_Name>Fraktur</Collection_Name>
+                </record>
+            </x:context>
+            <x:expect-assert id="Title1"/>
+        </x:scenario>
+        <x:scenario label="invalid: empty title 2">
+            <x:context>
+                <record airflow-record-id="1">
+                    <Item_No>frk00001</Item_No>
+                    <Title/>
+                    <Creator>Anonymous</Creator>
+                    <Description>Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.</Description>
+                    <Creation_Date>ca. 1825</Creation_Date>
+                    <Format>tif</Format>
+                    <Subject> Flowers | Planters (containers) | Pottery | Rosettes | Tulips</Subject>
+                    <Language>German; English</Language>
+                    <Identifier>http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001</Identifier>
+                    <Thumbnail>http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg</Thumbnail>
+                    <Type>Still Image</Type>
+                    <Collection_Name>Fraktur</Collection_Name>
+                </record>
+            </x:context>
+            <x:expect-assert id="Title1"/>
+        </x:scenario>
+    </x:scenario>
+    
+</x:description>

--- a/tests/schematron/csv_reqd_fields.xspec
+++ b/tests/schematron/csv_reqd_fields.xspec
@@ -2,52 +2,15 @@
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
     schematron="../../validations/csv_reqd_fields.sch">
     
-    <x:scenario label="RequiredElementsPattern">
-        <x:scenario label="valid: title">
-            <x:context>
-                <record airflow-record-id="1">
-                    <Item_No>frk00001</Item_No>
-                    <Title>Birth and Baptismal Certificate (Geburts und Taufschein) for Jonas Laber</Title>
-                    <Creator>Anonymous</Creator>
-                    <Description>Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.</Description>
-                    <Creation_Date>ca. 1825</Creation_Date>
-                    <Format>tif</Format>
-                    <Subject> Flowers | Planters (containers) | Pottery | Rosettes | Tulips</Subject>
-                    <Language>German; English</Language>
-                    <Identifier>http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001</Identifier>
-                    <Thumbnail>http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg</Thumbnail>
-                    <Type>Still Image</Type>
-                    <Collection_Name>Fraktur</Collection_Name>
-                </record>
-            </x:context>
-            <x:expect-valid/>
-        </x:scenario>
-        <x:scenario label="not valid: missing title">
-            <x:context>
-                <record airflow-record-id="1">
-                    <Item_No>frk00001</Item_No>
-                    <Creator>Anonymous</Creator>
-                    <Description>Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.</Description>
-                    <Creation_Date>ca. 1825</Creation_Date>
-                    <Format>tif</Format>
-                    <Subject> Flowers | Planters (containers) | Pottery | Rosettes | Tulips</Subject>
-                    <Language>German; English</Language>
-                    <Identifier>http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001</Identifier>
-                    <Thumbnail>http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg</Thumbnail>
-                    <Type>Still Image</Type>
-                    <Collection_Name>Fraktur</Collection_Name>
-                </record>
-            </x:context>
-            <x:expect-assert id="Required1"/>
-        </x:scenario>        
-    </x:scenario>
+    <!-- Valid scenario includes both upper and lower case title fields -->     
     
-    <x:scenario label="TitleElementPattern">
+    <x:scenario label="RequiredElementsPattern">
         <x:scenario label="valid">
             <x:context>
                 <record airflow-record-id="1">
                     <Item_No>frk00001</Item_No>
                     <Title>Birth and Baptismal Certificate (Geburts und Taufschein) for Jonas Laber</Title>
+                    <title>Birth and Baptismal Certificate (Geburts und Taufschein) for Jonas Laber</title>
                     <Creator>Anonymous</Creator>
                     <Description>Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.</Description>
                     <Creation_Date>ca. 1825</Creation_Date>
@@ -61,45 +24,149 @@
                 </record>
             </x:context>
             <x:expect-valid/>
-        </x:scenario>
-        <x:scenario label="invalid: empty title 1">
-            <x:context>
-                <record airflow-record-id="1">
-                    <Item_No>frk00001</Item_No>
-                    <Title></Title>
-                    <Creator>Anonymous</Creator>
-                    <Description>Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.</Description>
-                    <Creation_Date>ca. 1825</Creation_Date>
-                    <Format>tif</Format>
-                    <Subject> Flowers | Planters (containers) | Pottery | Rosettes | Tulips</Subject>
-                    <Language>German; English</Language>
-                    <Identifier>http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001</Identifier>
-                    <Thumbnail>http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg</Thumbnail>
-                    <Type>Still Image</Type>
-                    <Collection_Name>Fraktur</Collection_Name>
-                </record>
-            </x:context>
-            <x:expect-assert id="Title1"/>
-        </x:scenario>
-        <x:scenario label="invalid: empty title 2">
-            <x:context>
-                <record airflow-record-id="1">
-                    <Item_No>frk00001</Item_No>
-                    <Title/>
-                    <Creator>Anonymous</Creator>
-                    <Description>Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.</Description>
-                    <Creation_Date>ca. 1825</Creation_Date>
-                    <Format>tif</Format>
-                    <Subject> Flowers | Planters (containers) | Pottery | Rosettes | Tulips</Subject>
-                    <Language>German; English</Language>
-                    <Identifier>http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001</Identifier>
-                    <Thumbnail>http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg</Thumbnail>
-                    <Type>Still Image</Type>
-                    <Collection_Name>Fraktur</Collection_Name>
-                </record>
-            </x:context>
-            <x:expect-assert id="Title1"/>
+        </x:scenario>                
+        <x:scenario label="not valid">
+            <x:scenario label="not valid: Missing Title Upper Case">
+                <x:context>
+                    <record airflow-record-id="1">
+                        <Item_No>frk00001</Item_No>
+                        <Creator>Anonymous</Creator>
+                        <Description>Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.</Description>
+                        <Creation_Date>ca. 1825</Creation_Date>
+                        <Format>tif</Format>
+                        <Subject> Flowers | Planters (containers) | Pottery | Rosettes | Tulips</Subject>
+                        <Language>German; English</Language>
+                        <Identifier>http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001</Identifier>
+                        <Thumbnail>http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg</Thumbnail>
+                        <Type>Still Image</Type>
+                        <Collection_Name>Fraktur</Collection_Name>
+                    </record>
+                </x:context>
+                <x:expect-assert id="Required1"/>
+            </x:scenario> 
+            <x:scenario label="not valid: missing title lower case">
+                <x:context>
+                    <record airflow-record-id="1">
+                        <item_no>frk00001</item_no>
+                        <creator>Anonymous</creator>
+                        <description>Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.</description>
+                        <creation_Date>ca. 1825</creation_Date>
+                        <format>tif</format>
+                        <subject> Flowers | Planters (containers) | Pottery | Rosettes | Tulips</subject>
+                        <language>German; English</language>
+                        <identifier>http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001</identifier>
+                        <thumbnail>http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg</thumbnail>
+                        <type>Still Image</type>
+                        <collection_name>Fraktur</collection_name>
+                    </record>
+                </x:context>
+                <x:expect-assert id="Required2"/>
+            </x:scenario> 
         </x:scenario>
     </x:scenario>
-    
+ 
+ <!-- Valid scenario includes both upper and lower case title fields -->
+ 
+    <x:scenario label="TitleElementPattern">
+        <x:scenario label="valid">      
+            <x:context>
+                <record airflow-record-id="1">
+                    <Item_No>frk00001</Item_No>
+                    <Title>Birth and Baptismal Certificate (Geburts und Taufschein) for Jonas Laber</Title>
+                    <title>Birth and Baptismal Certificate (Geburts und Taufschein) for Jonas Laber</title>
+                    <Creator>Anonymous</Creator>
+                    <Description>Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.</Description>
+                    <Creation_Date>ca. 1825</Creation_Date>
+                    <Format>tif</Format>
+                    <Subject> Flowers | Planters (containers) | Pottery | Rosettes | Tulips</Subject>
+                    <Language>German; English</Language>
+                    <Identifier>http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001</Identifier>
+                    <Thumbnail>http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg</Thumbnail>
+                    <Type>Still Image</Type>
+                    <Collection_Name>Fraktur</Collection_Name>
+                </record>
+            </x:context>
+            <x:expect-valid/>          
+        </x:scenario>
+        <x:scenario label="invalid: Upper Case Fields">
+            <x:scenario label="invalid: empty title 1">
+                <x:context>
+                    <record airflow-record-id="1">
+                        <Item_No>frk00001</Item_No>
+                        <Title></Title>
+                        <Creator>Anonymous</Creator>
+                        <Description>Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.</Description>
+                        <Creation_Date>ca. 1825</Creation_Date>
+                        <Format>tif</Format>
+                        <Subject> Flowers | Planters (containers) | Pottery | Rosettes | Tulips</Subject>
+                        <Language>German; English</Language>
+                        <Identifier>http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001</Identifier>
+                        <Thumbnail>http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg</Thumbnail>
+                        <Type>Still Image</Type>
+                        <Collection_Name>Fraktur</Collection_Name>
+                    </record>
+                </x:context>
+                <x:expect-assert id="Title1"/>
+            </x:scenario>
+            <x:scenario label="invalid: empty title 2">
+                <x:context>
+                    <record airflow-record-id="1">
+                        <Item_No>frk00001</Item_No>
+                        <Title/>
+                        <Creator>Anonymous</Creator>
+                        <Description>Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.</Description>
+                        <Creation_Date>ca. 1825</Creation_Date>
+                        <Format>tif</Format>
+                        <Subject> Flowers | Planters (containers) | Pottery | Rosettes | Tulips</Subject>
+                        <Language>German; English</Language>
+                        <Identifier>http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001</Identifier>
+                        <Thumbnail>http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg</Thumbnail>
+                        <Type>Still Image</Type>
+                        <Collection_Name>Fraktur</Collection_Name>
+                    </record>
+                </x:context>
+                <x:expect-assert id="Title1"/>
+            </x:scenario>
+        </x:scenario>
+        <x:scenario label="invalid: lower case fields">
+            <x:scenario label="invalid: empty title 1">
+                <x:context>
+                    <record airflow-record-id="1">
+                        <item_no>frk00001</item_no>
+                        <title></title>
+                        <creator>Anonymous</creator>
+                        <description>Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.</description>
+                        <creation_date>ca. 1825</creation_date>
+                        <format>tif</format>
+                        <subject> Flowers | Planters (containers) | Pottery | Rosettes | Tulips</subject>
+                        <language>German; English</language>
+                        <identifier>http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001</identifier>
+                        <thumbnail>http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg</thumbnail>
+                        <type>Still Image</type>
+                        <collection_name>Fraktur</collection_name>
+                    </record>
+                </x:context>
+                <x:expect-assert id="Title2"/>
+            </x:scenario>
+            <x:scenario label="invalid: empty title 2">
+                <x:context>
+                    <record airflow-record-id="1">
+                        <item_no>frk00001</item_no>
+                        <title/>
+                        <creator>Anonymous</creator>
+                        <description>Hand-drawn; hand-colored; hand-lettered. The main text, hand-lettered in German Fraktur with blanks handwritten in German script, is framed by a rectangular border. The county and town are written in English. Below it is a confirmation note in German script. On each side is a scalloped pot with a tulip, adorned with leaves, smaller blossoms and two scalloped flowers. Several rosettes and flowers are above and below the text frame. The abbreviation v d m after the pastors name stands for verbi divini magister, which means Teacher of Gods Word. Based on designs by Abraham Huth.</description>
+                        <creation_date>ca. 1825</creation_date>
+                        <format>tif</format>
+                        <subject> Flowers | Planters (containers) | Pottery | Rosettes | Tulips</subject>
+                        <language>German; English</language>
+                        <identifier>http://libwww.freelibrary.org/diglib/searchItem.cfm?itemID=frk00001</identifier>
+                        <thumbnail>http://libwww.freelibrary.org/digicol/fraktur/frk00001t.jpg</thumbnail>
+                        <type>Still Image</type>
+                        <collection_name>Fraktur</collection_name>
+                    </record>
+                </x:context>
+                <x:expect-assert id="Title2"/>
+            </x:scenario>
+        </x:scenario>
+    </x:scenario>   
 </x:description>

--- a/validations/csv_reqd_fields.sch
+++ b/validations/csv_reqd_fields.sch
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://purl.oclc.org/dsdl/schematron">
+    
+    <pattern id="RequiredElementsPattern">
+        <title>CSV fields required</title>
+        <rule context="record">
+            <assert test="Title" id="Required1" role="error">There must be a title</assert>
+        </rule>
+    </pattern>
+    <pattern id="TitleElementPattern">
+        <title>Required fields must contain text.</title>
+        <rule context="record/Title">
+            <assert test="normalize-space(.)" id="Title1" role="error">The title property must contain text</assert>
+        </rule>
+    </pattern>
+    
+</schema>

--- a/validations/csv_reqd_fields.sch
+++ b/validations/csv_reqd_fields.sch
@@ -4,13 +4,17 @@
     <pattern id="RequiredElementsPattern">
         <title>CSV fields required</title>
         <rule context="record">
-            <assert test="Title" id="Required1" role="error">There must be a title</assert>
+            <assert test="Title" id="Required1" role="error">There must be a Title</assert>
+            <assert test="title" id="Required2" role="error">There must be a title</assert>
         </rule>
     </pattern>
     <pattern id="TitleElementPattern">
         <title>Required fields must contain text.</title>
         <rule context="record/Title">
             <assert test="normalize-space(.)" id="Title1" role="error">The title property must contain text</assert>
+        </rule>
+        <rule context="record/title">
+            <assert test="normalize-space(.)" id="Title2" role="error">The title property must contain text</assert>
         </rule>
     </pattern>
     


### PR DESCRIPTION
What this PR does:

- adds schematron for post-harvest validation of custom CSV-XML (note that it only tests for title, since rights statements are added later as part of the XSLT transformation)
- adds associated xspec to test the schematron