### PR TITLE
updated scranton transform so setspec lookup doesn't force lowercase

### DIFF
--- a/transforms/uscranton_csv.xsl
+++ b/transforms/uscranton_csv.xsl
@@ -45,7 +45,7 @@
 
     <!-- Collection Name -->
     <xsl:template match="Collection_Name">
-        <xsl:if test="normalize-space(lower-case(.))">
+        <xsl:if test="normalize-space(.)">
           <xsl:element name="dcterms:isPartOf">
               <xsl:value-of select="normalize-space(.)"/>
           </xsl:element>


### PR DESCRIPTION
pardon the branch name

setspec lookup in xslt was using lower-case function when it shouldn't be; fixed it