### PR TITLE
update local identifier for Penn Women transform

### DIFF
--- a/tests/xslt/penn_women.xspec
+++ b/tests/xslt/penn_women.xspec
@@ -733,7 +733,7 @@
          <dcterms:creator>Wheatley, Phillis, 1753-1784</dcterms:creator>
          <dcterms:subject>United States -- History -- Revolution, 1775-1783 -- Poetry</dcterms:subject>
          <dcterms:subject>PS866 .W5 L5</dcterms:subject>
-         <dcterms:identifier>padig:PENN-wheatley/liberty/liberty</dcterms:identifier>
+         <dcterms:identifier>padig:PENN-celebration-wheatley-liberty-liberty</dcterms:identifier>
          <edm:isShownAt>https://digital.library.upenn.edu/women/wheatley/liberty/liberty.html</edm:isShownAt>
          <schema:fileFormat>text/html</schema:fileFormat>
          <dcterms:description>Boston: Warden and Russell, 1784</dcterms:description>
@@ -759,7 +759,7 @@
            <dcterms:creator>Wheatley, Phillis, 1753-1784</dcterms:creator>
            <dcterms:subject>United States -- History -- Revolution, 1775-1783 -- Poetry</dcterms:subject>
            <dcterms:subject>PS866 .W5 L5</dcterms:subject>
-           <dcterms:identifier>padig:PENN-wheatley/liberty/liberty</dcterms:identifier>
+           <dcterms:identifier>padig:PENN-celebration-wheatley-liberty-liberty</dcterms:identifier>
            <edm:isShownAt>https://digital.library.upenn.edu/women/wheatley/liberty/liberty.html</edm:isShownAt>
            <schema:fileFormat>text/html</schema:fileFormat>
            <dcterms:description>Boston: Warden and Russell, 1784</dcterms:description>
@@ -917,7 +917,7 @@
            <dcterms:creator>Wheatley, Phillis, 1753-1784</dcterms:creator>
            <dcterms:subject>United States -- History -- Revolution, 1775-1783 -- Poetry</dcterms:subject>
            <dcterms:subject>PS866 .W5 L5</dcterms:subject>
-           <dcterms:identifier>padig:PENN-wheatley/liberty/liberty</dcterms:identifier>
+           <dcterms:identifier>padig:PENN-celebration-wheatley-liberty-liberty</dcterms:identifier>
            <edm:isShownAt>https://digital.library.upenn.edu/women/wheatley/liberty/liberty.html</edm:isShownAt>
            <schema:fileFormat>text/html</schema:fileFormat>
            <dcterms:description>Boston: Warden and Russell, 1784</dcterms:description>

--- a/transforms/penn_women.xsl
+++ b/transforms/penn_women.xsl
@@ -36,18 +36,26 @@
     <!-- Create elements based on dc:identifier -->
     
     <xsl:template match="dc:identifier">
-        <xsl:variable name="objID" select='substring-after(.,"/cdm/ref/")'/>
-        <xsl:variable name="baseURL" select='substring-before(.,"cdm/ref/")'/>
-        <xsl:variable name="itemID" select='substring-after(.,"/id/")'/>
-        <xsl:variable name="colID" select='substring-before(substring-after(.,"https://digital.library.upenn.edu/women/"), ".html")'/>
-        <xsl:variable name="lowerID" select='lower-case(.)'/>
+      
+        <xsl:variable name="itemID-html" select='substring-before(substring-after(.,"https://digital.library.upenn.edu/women/"), ".html")'/>
+        <xsl:variable name="itemID-pdf" select='substring-before(substring-after(.,"https://digital.library.upenn.edu/women/"), ".pdf")'/>
+        <xsl:variable name="itemID-html-clean" select="translate($itemID-html,'/','-')"/>
+        <xsl:variable name="itemID-pdf-clean" select="translate($itemID-pdf,'/','-')"/>
 
         <!-- Local identifier -->
-        <xsl:if test="normalize-space(.)!=''">
-            <xsl:element name="dcterms:identifier">
-                <xsl:value-of>padig:PENN-</xsl:value-of><xsl:value-of select="normalize-space($colID)"/>
-            </xsl:element>
-        </xsl:if>
+        
+        <xsl:choose>
+            <xsl:when test="$itemID-html">
+                <xsl:element name="dcterms:identifier">
+                    <xsl:value-of>padig:PENN-celebration-</xsl:value-of><xsl:value-of select="normalize-space($itemID-html-clean)"/>
+                </xsl:element>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:element name="dcterms:identifier">
+                    <xsl:value-of>padig:PENN-celebration-</xsl:value-of><xsl:value-of select="normalize-space($itemID-pdf-clean)"/>
+                </xsl:element>
+            </xsl:otherwise>
+        </xsl:choose>    
 
         <!-- URL -->
             <xsl:if test="normalize-space(.)!=''">


### PR DESCRIPTION
What this PR does:
- update local identifier variables to handle input from both HTML and PDF URLs, with a preference for HTML when both are present
- update local identifier variables to replace slashes with hyphens so that Blacklight record URLs will resolve
- update xspec to reflect the above changes