### PR TITLE
add more rights to FLP

### DIFF
--- a/fixtures/free_library_test.csv.xml
+++ b/fixtures/free_library_test.csv.xml
@@ -13,5 +13,6 @@
     <Type>Still Image</Type>
     <Collection_Name>Fraktur</Collection_Name>
     <Country>Italy</Country>
+    <Rights>http://rightsstatements.org/vocab/InC/1.0/</Rights>
   </record>
 </collection>

--- a/tests/xslt/free_library_csv.xspec
+++ b/tests/xslt/free_library_csv.xspec
@@ -73,9 +73,13 @@
   </x:scenario>
 
   <!-- Rights -->
-  <x:scenario label="rights processing">
+  <x:scenario label="static rights statement">
     <x:context href="../../fixtures/free_library_test.csv.xml"/>
     <x:expect label="textual rights statment is transformed to dcterms:rights" test='oai_dc:dc/dcterms:rights = "High-resolution images from the Free Library of Philadelphia&apos;s collections are available for publication and other uses, within copyright and licensing restrictions. Please take note of the Item No which you will need to fill out the Reproduction Services form."'/>
+  </x:scenario>
+  <x:scenario label="rightsstatement.org processing">
+    <x:context href="../../fixtures/free_library_test.csv.xml"/>
+    <x:expect label="URI rights statment is transformed to edm:rights" test='oai_dc:dc/edm:rights = "http://rightsstatements.org/vocab/InC/1.0/"'/>
   </x:scenario>
 
   <!-- Subject -->
@@ -113,6 +117,7 @@
         <dcterms:type>Still Image</dcterms:type>
         <dcterms:isPartOf>Fraktur</dcterms:isPartOf>
         <dcterms:spatial>Italy</dcterms:spatial>
+        <edm:rights>http://rightsstatements.org/vocab/InC/1.0/</edm:rights>
         <dcterms:rights>High-resolution images from the Free Library of Philadelphia's collections are available for publication and other uses, within copyright and licensing restrictions. Please take note of the Item No which you will need to fill out the Reproduction Services form.</dcterms:rights>
         <edm:dataProvider>Free Library of Philadelphia</edm:dataProvider>
         <edm:provider>PA Digital</edm:provider>

--- a/transforms/free_library_csv.xsl
+++ b/transforms/free_library_csv.xsl
@@ -132,6 +132,26 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
+    
+    <!-- Rights -->
+    <xsl:template match="Rights">
+        <xsl:choose>
+            <xsl:when test="starts-with(., 'http://rightsstatements.org/vocab/') or starts-with(., 'http://creativecommons.org/') or starts-with(., 'https://creativecommons.org/')">
+                <xsl:if test="normalize-space(.)!=''">
+                    <xsl:element name="edm:rights">
+                        <xsl:value-of select="normalize-space(.)"/>
+                    </xsl:element>
+                </xsl:if>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:if test="normalize-space(.)!=''">
+                    <xsl:element name="dcterms:rights">
+                        <xsl:value-of select="normalize-space(.)"/>
+                    </xsl:element>
+                </xsl:if>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
 
     <!-- Thumbnail URL -->
     <xsl:template match="Thumbnail">
@@ -204,9 +224,9 @@
 
     <!-- Rights -->
     <xsl:template name="static-rights-statement">
-      <xsl:element name="dcterms:rights">
-        <xsl:value-of>High-resolution images from the Free Library of Philadelphia&apos;s collections are available for publication and other uses, within copyright and licensing restrictions. Please take note of the Item No which you will need to fill out the Reproduction Services form.</xsl:value-of>
-      </xsl:element>
+        <xsl:element name="dcterms:rights">
+            <xsl:value-of>High-resolution images from the Free Library of Philadelphia&apos;s collections are available for publication and other uses, within copyright and licensing restrictions. Please take note of the Item No which you will need to fill out the Reproduction Services form.</xsl:value-of>
+        </xsl:element>       
     </xsl:template>
 
     <!-- Subject -->


### PR DESCRIPTION
What this PR does:

- adds additional transform for Rights field when present in CSV (note: hard coded static rights statement is still generated in addition; I was not able to make this conditional - will need to follow up with Leanne)
- updates tests to reflect the above