### PR TITLE
update dcingest schematron

### DIFF
--- a/tests/schematron/dcingest_reqd_fields.xspec
+++ b/tests/schematron/dcingest_reqd_fields.xspec
@@ -10,7 +10,7 @@
       <x:context href="../../fixtures/schematron/invalid_missing_dc_title.xml"/>
       <x:expect-assert id="Required1"/>
     </x:scenario>
-    <x:scenario label="valid: dc:rights>">
+    <x:scenario label="valid: dc:rights">
       <x:context href="../../fixtures/schematron/valid_dc.xml"/>
       <x:expect-valid/>
     </x:scenario>
@@ -24,6 +24,7 @@
       <x:expect-assert id="Required2"/>
     </x:scenario>
   </x:scenario>
+  <!--
   <x:scenario label="TitleElementPattern">
     <x:scenario label="valid">
       <x:context href="../../fixtures/schematron/valid_dc.xml"/>
@@ -56,6 +57,7 @@
       </x:scenario>
     </x:scenario>
   </x:scenario>
+  -->
   <x:scenario label="NoHarvest">
     <x:scenario label="valid">
       <x:context href="../../fixtures/schematron/valid_dc.xml"/>

--- a/validations/dcingest_reqd_fields.sch
+++ b/validations/dcingest_reqd_fields.sch
@@ -16,6 +16,7 @@
           <assert test="dc:rights" id="Required2" role="error">There must be a rights statement</assert>
         </rule>
     </pattern>
+  <!--
     <pattern id="TitleElementPattern">
       <title>Required fields must contain text.</title>
         <rule context="oai_dc:dc/dc:title">
@@ -27,6 +28,7 @@
           <assert test="normalize-space(.)" id="Rights1" role="error">The rights property must contain text</assert>
         </rule>
       </pattern>
+      -->
       <pattern id="NoHarvest">
         <title>Additional Metadata Requirements</title>
         <rule context="oai_dc:dc/*">


### PR DESCRIPTION
What this PR does:
- remove test for empty title
- remove test for empty rights

Since empty fields are removed at the transform step, testing for them post-ingest may not be necessary. This change will also help us continue testing the APS dag.

Code has been commented out rather than removed to facilitate easy restoration if we change our minds. 