### PR TITLE
Authenticate dockerhub pulls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
   build:
     docker:
       - image: circleci/python:3.7.2
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
 
     steps:
       - checkout

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,10 @@ test-xslt:
 		docker-compose run xspec "$$xspectest" ; \
 	done
 
-test-ci: test-bash test-coverage
+test-ci: test-login test-bash test-coverage
+
+test-login:
+	@docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASSWORD}
 
 test-bash:
 	@echo "CI/CD testing *.xspec with Docker & shell scripts"


### PR DESCRIPTION
dockerhub will begin to throttle non anthenticated pulls so we need to
authenticate our pulls now.