### PR TITLE
Add lafayatte setspecs to lookup

### DIFF
--- a/transforms/remediations/lookup.xsl
+++ b/transforms/remediations/lookup.xsl
@@ -156,6 +156,10 @@
         <padig:set string="Widener Online Newsletters">p16069coll20</padig:set>
         <!-- Lafayette -->
         <padig:set string="College Archives Image Collection">collection:College_Archives_Image_Collection</padig:set>
+        <padig:set string="Gerald &amp; Rella Warner Dutch East Indies Negatives">collection:Gerald_&_Rella_Warner_Dutch_East_Indies_Negatives</padig:set>
+        <padig:set string="Gerald &amp; Rella Warner Japan Slides">collection:Gerald_&_Rella_Warner_Japan_Slides</padig:set>
+        <padig:set string="Gerald &amp; Rella Warner Manchuria Negatives">collection:Gerald_&_Rella_Warner_Manchuria_Negatives</padig:set>
+        <padig:set string="Gerald &amp; Rella Warner Postcards">collection:Gerald_&_Rella_Warner_Taiwan_Negatives</padig:set>
         <padig:set string="Lafayette Newspaper Archive">collection:Lafayette_Newspaper_archive</padig:set>
         <padig:set string="Lafayette Magazine Archive">collection:Lafayette_Magazine_archive</padig:set>
         <padig:set string="Marquis De Lafayette Prints Collection">collection:Marquis_de_Lafayette_Prints_Collection</padig:set>


### PR DESCRIPTION
@lfinnigan @htomren I think the inclusion of the & character renders the inputted XML field from Lafayette invalid, which will cause the transform to fail. Creating this PR, though, to test and get your feedback. Let me know what you think!