### PR TITLE
Add Penn State set specs to lookup

### DIFF
--- a/transforms/remediations/lookup.xsl
+++ b/transforms/remediations/lookup.xsl
@@ -709,6 +709,48 @@
         <padig:set string="Presbyterian Historical Society Video Collection">islandora_video_collection</padig:set>
         <padig:set string="Religious News Service Photographs">islandora_rns</padig:set>
         <padig:set string="Relocation of Japanese-Americans during the Second World War">islandora_slides_b34</padig:set>
+        
+    <!-- Penn State -->
+        <padig:set string="A Few Good Women">afgw</padig:set>
+        <padig:set string="A. E. Bye Papers">aebye</padig:set>
+        <padig:set string="A. J. Thompson Civil War Diary">ajt</padig:set>
+        <padig:set string="Alice Marshall Collection">amc</padig:set>
+        <padig:set string="Amalgamated Association of Iron, Steel, and Tin Workers of North America Records">amalgamated</padig:set>
+        <padig:set string="Anderson and Ellis Art Education Collection">arted</padig:set>
+        <padig:set string="Brent Wilson Papers">brentwilson</padig:set>
+        <padig:set string="Cresson Literary Society Records">cls</padig:set>
+        <padig:set string="Daniel Elias Frantz Diary">def</padig:set>
+        <padig:set string="Digital Map Drawer">maps1</padig:set>
+        <padig:set string="Edwin Forbes Civil War Etchings">Forbes</padig:set>
+        <padig:set string="Elisha J. Bracken Civil War Diary">ejb</padig:set>
+        <padig:set string="George and Alice Beatty Papers">gbp</padig:set>
+        <padig:set string="George Hoenshel Fleming Sr. Family Papers">fleming</padig:set>
+        <padig:set string="George Medrick Papers">medrick</padig:set>
+        <padig:set string="Harold Rasmussen Scrapbooks, Badges, and Buttons">rasmussen</padig:set>
+        <padig:set string="Howard Truman Curtiss Papers">curtiss</padig:set>
+        <padig:set string="Jerry Doyle Papers">jdp</padig:set>
+        <padig:set string="John Chorey Papers">chorey</padig:set>
+        <padig:set string="Joseph Priestley Collection">priestley</padig:set>
+        <padig:set string="Kirschner Family Papers">kirschner</padig:set>
+        <padig:set string="Mira Dock Lantern Slides">mdfls</padig:set>
+        <padig:set string="Morris W. Hackman Civil War Diary">mwh</padig:set>
+        <padig:set string="Penn State Froth">froth</padig:set>
+        <padig:set string="Penn State Libraries Photo Archive">psuphotos</padig:set>
+        <padig:set string="Pennsylvania Bridges Collection">pab</padig:set>
+        <padig:set string="Philip Murray Papers">murray</padig:set>
+        <padig:set string="Pinkerton's National Detective Agency"></padig:set>
+        <padig:set string="Sarah Chamberlin Eccleston Diary and Journal, 1864-1916">chamberlin</padig:set>
+        <padig:set string="T. R. Johns">trjohns</padig:set>
+        <padig:set string="Thomas W. Benson Political Protest Collection">benson</padig:set>
+        <padig:set string="Union League of Philadelphia Archives">ulp</padig:set>
+        <padig:set string="United Mine Workers of America Photographic, Graphic, and Artifacts Collection">umwap</padig:set>
+        <padig:set string="United Mine Workers of America, President's Office Correspondence">umwac</padig:set>
+        <padig:set string="United Steelworkers of America District 33 Records">district33</padig:set>
+        <padig:set string="Walter R. Collins Civil War Diaries and Photograph">wrc</padig:set>
+        <padig:set string="Washington Literary Society Records, 1859-1895">wls</padig:set>
+        <padig:set string="William H.H. Fisher Civil War Diary">whf</padig:set>
+        <padig:set string="World War I Glass Plate Stereographs">ww1stereo</padig:set>
+        <padig:set string="WPA Bituminous Coal Mine Maps">wpamaps</padig:set>
     </xsl:param>
 
     <!-- lookup table collection name by identifier -->


### PR DESCRIPTION
Penn State set specs were not in the lookup because the current transform does not require it.

Added set specs in case we change our approach. Leanne will confirm with Linda.