### PR TITLE
PD-443 Penn State content warning mappings

### DIFF
--- a/fixtures/cdm_pennstate_contentwarning.xml
+++ b/fixtures/cdm_pennstate_contentwarning.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+    <responseDate>2023-06-13T14:37:40Z</responseDate>
+    <request verb="ListRecords" metadataPrefix="oai_qdc" set="ww1stereo">http://digital.libraries.psu.edu/oai/oai.php</request>  
+    <ListRecords>
+        <record>
+            <header>
+                <identifier>oai:digital.libraries.psu.edu:ww1stereo/523</identifier>
+                <datestamp>2022-10-18</datestamp>
+                <setSpec>ww1stereo</setSpec>
+            </header>
+            <metadata>
+                <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://worldcat.org/xmlschemas/qdc-1.0/ http://worldcat.org/xmlschemas/qdc/1.0/qdc-1.0.xsd http://purl.org/net/oclcterms http://worldcat.org/xmlschemas/oclcterms/1.4/oclcterms-1.4.xsd">
+                    <dc:title>Cadavre Allemand</dc:title>
+                    <dcterms:alternative>[…] - Cadavre Allemand</dcterms:alternative>
+                    <dcterms:created>1914/1918</dcterms:created>
+                    <dc:subject>World War, 1914-1918</dc:subject>
+                    <dcterms:temporal>1914/1918</dcterms:temporal>
+                    <dcterms:medium>stereographs: photographs</dcterms:medium>
+                    <dc:language>fre</dc:language>
+                    <dcterms:isPartOf>World War I glass plate stereographs</dcterms:isPartOf>
+                    <dcterms:isPartOf>Deceased and wounded soldiers</dcterms:isPartOf>
+                    <dcterms:isPartOf>HCLA 09531</dcterms:isPartOf>
+                    <dc:source>Box 1, Carton 1, Negative Number 54A</dc:source>
+                    <dc:source>Pennsylvania State University. Special Collections Library</dc:source>
+                    <dc:source>http://resources.libraries.psu.edu/findingaids/9531.htm</dc:source>
+                    <dc:rights>http://rightsstatements.org/vocab/NKC/1.0/</dc:rights>
+                    <dc:identifier>pstsc_09531_108</dc:identifier>
+                    <dc:type>Image;StillImage</dc:type>
+                    <dcterms:audience>true</dcterms:audience>
+                    <dc:identifier>http://digital.libraries.psu.edu/cdm/ref/collection/ww1stereo/id/523</dc:identifier>
+                </oai_qdc:qualifieddc>
+            </metadata>
+        </record>
+    </ListRecords>
+</OAI-PMH>

--- a/tests/xslt/cdm_pennstate.xspec
+++ b/tests/xslt/cdm_pennstate.xspec
@@ -1539,7 +1539,7 @@
      <x:context href="../../fixtures/cdm_pennstate_contentwarning.xml"/>
      <x:expect label="content warning description generated" test="oai_dc:dc/dcterms:description = 'The following item contains content that may be offensive or upsetting.'"/>
      <x:expect label="preview not generated" test="not(oai_dc:dc/edm:preview)"/>
-     <x:expect label="preview not generated" test="not(oai_dc:dc/svcs:hasService)"/>
-     <x:expect label="preview not generated" test="not(oai_dc:dc/dcterms:isReferencedBy)"/>
+     <x:expect label="IIIF Base URL not generated" test="not(oai_dc:dc/svcs:hasService)"/>
+     <x:expect label="IIIF Manifest not generated" test="not(oai_dc:dc/dcterms:isReferencedBy)"/>
    </x:scenario>
  </x:description>

--- a/tests/xslt/cdm_pennstate.xspec
+++ b/tests/xslt/cdm_pennstate.xspec
@@ -1527,4 +1527,19 @@
      <x:context href="../../fixtures/cdm_pennstate.xml"/>
      <x:expect label="preview generates and maps" test="oai_dc:dc/dcterms:isReferencedBy = 'http://digital.libraries.psu.edu/iiif/info/p15037coll3/0/manifest.json'"/>
    </x:scenario>
+
+ <!-- Penn State Content Warning -->
+
+  <x:scenario label="Penn State Content Warning not present">
+     <x:context href="../../fixtures/cdm_pennstate.xml"/>
+     <x:expect label="content warning description not generated" test="oai_dc:dc/dcterms:description != 'The following item contains content that may be offensive or upsetting.'"/>
+   </x:scenario>
+
+  <x:scenario label="Penn State Content Warning true">
+     <x:context href="../../fixtures/cdm_pennstate_contentwarning.xml"/>
+     <x:expect label="content warning description generated" test="oai_dc:dc/dcterms:description = 'The following item contains content that may be offensive or upsetting.'"/>
+     <x:expect label="preview not generated" test="not(oai_dc:dc/edm:preview)"/>
+     <x:expect label="preview not generated" test="not(oai_dc:dc/svcs:hasService)"/>
+     <x:expect label="preview not generated" test="not(oai_dc:dc/dcterms:isReferencedBy)"/>
+   </x:scenario>
  </x:description>

--- a/transforms/cdm_generic.xsl
+++ b/transforms/cdm_generic.xsl
@@ -21,6 +21,7 @@
     <!-- Use includes here if you need to separate out templates for either use specific to a dataset or use generic enough for multiple providers (like remediation.xslt). -->
 
     <xsl:include href="oai_base_crosswalk.xsl"/>
+    <xsl:include href="cdm_generic_templates.xsl"/>
 
     <!-- Create collection name -->
     
@@ -38,76 +39,4 @@
             <xsl:call-template name="iiifManifest"/>
         </xsl:if>
     </xsl:template>
-
-    <!-- templates -->
-    
-    <!-- isPartOf -->
-    <xsl:template name="isPartOf">
-            <xsl:variable name="setID" select="normalize-space(lower-case(.))"/>
-            <xsl:if test="$setID = $setSpecList/padig:set">
-                <xsl:element name="dcterms:isPartOf">
-                    <xsl:value-of select="$setSpecList/padig:set[. = $setID]/@string"/>
-                </xsl:element>
-            </xsl:if>
-    </xsl:template>
-    
-    <!-- dataProvider -->
-    <xsl:template name="dataProvider">
-        <xsl:variable name="baseURL" select='substring-before(.,"cdm/ref/")'/>
-        <xsl:if test="$baseURL = $oaiUrl/padig:url">
-            <xsl:element name="edm:dataProvider">
-                <xsl:value-of select="$oaiUrl/padig:url[. = $baseURL]/@string"/>
-            </xsl:element>
-        </xsl:if>
-    </xsl:template>
-    
-    <!-- identifier -->
-    <xsl:template name="identifier">
-        <xsl:variable name="itemID" select='substring-after(.,"/id/")'/>
-        <xsl:variable name="colID" select='substring-before(substring-after(.,"collection/"), "/id")'/>
-        <xsl:variable name="baseURL" select='substring-before(.,"cdm/ref/")'/>
-        
-        <xsl:element name="dcterms:identifier">
-            <xsl:value-of>padig:</xsl:value-of><xsl:value-of select="$oaiUrl/padig:url[. = $baseURL]/@code"/><xsl:value-of>-</xsl:value-of><xsl:value-of select="$colID"/><xsl:value-of>-</xsl:value-of><xsl:value-of select="$itemID"/>
-        </xsl:element>
-    </xsl:template>
-    
-    <!-- isShownAt -->
-    <xsl:template name="isShownAt">
-        <xsl:element name="edm:isShownAt">
-            <xsl:value-of select="normalize-space(.)"/>
-        </xsl:element>
-    </xsl:template>
-    
-    <!-- preview -->
-    <xsl:template name="preview">
-        <xsl:variable name="baseURL" select='substring-before(.,"cdm/ref/")'/>
-        <xsl:variable name="objID" select='substring-after(.,"/cdm/ref/")'/>
-        
-        <xsl:element name="edm:preview">
-            <xsl:value-of select="$baseURL"/> <xsl:text>utils/getthumbnail/</xsl:text><xsl:value-of select="$objID"/>
-        </xsl:element>
-    </xsl:template>
-    
-    <!-- iiifBase -->
-    <xsl:template name="iiifBase">
-        <xsl:variable name="baseURL" select='substring-before(.,"cdm/ref/")'/>
-        <xsl:variable name="itemID" select='substring-after(.,"/id/")'/>
-        <xsl:variable name="colID" select='substring-before(substring-after(.,"collection/"), "/id")'/>
-        
-        <xsl:element name="svcs:hasService">
-            <xsl:value-of select="$baseURL"/> <xsl:text>digital/iiif/</xsl:text><xsl:value-of select="$colID"/><xsl:text>/</xsl:text><xsl:value-of select="$itemID"/>
-        </xsl:element>
-    </xsl:template>
-    
-    <!-- iiifManifest -->
-    <xsl:template name="iiifManifest">
-        <xsl:variable name="baseURL" select='substring-before(.,"cdm/ref/")'/>
-        <xsl:variable name="itemID" select='substring-after(.,"/id/")'/>
-        <xsl:variable name="colID" select='substring-before(substring-after(.,"collection/"), "/id")'/>
-        
-        <xsl:element name="dcterms:isReferencedBy">
-            <xsl:value-of select="$baseURL"/> <xsl:text>iiif/info/</xsl:text><xsl:value-of select="$colID"/><xsl:text>/</xsl:text><xsl:value-of select="$itemID"/><xsl:text>/manifest.json</xsl:text>
-        </xsl:element>
-    </xsl:template>  
 </xsl:stylesheet>

--- a/transforms/cdm_generic_templates.xsl
+++ b/transforms/cdm_generic_templates.xsl
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    xmlns:dpla="http://dp.la/about/map/"
+    xmlns:padig="http://padigital.org/ns"
+    xmlns:edm="http://www.europeana.eu/schemas/edm/"
+    xmlns:oclcdc="http://worldcat.org/xmlschemas/oclcdc-1.0/"
+    xmlns:oclcterms="http://purl.org/oclc/terms/"
+    xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+    xmlns:oai_dc='http://www.openarchives.org/OAI/2.0/oai_dc/'
+    xmlns:oclc="http://purl.org/oclc/terms/"
+    xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/"
+    xmlns:schema="http://schema.org"
+    xmlns:svcs="http://rdfs.org/sioc/services"
+    version="2.0">
+    <xsl:output omit-xml-declaration="no" method="xml" encoding="UTF-8" indent="yes"/>
+    <xsl:strip-space elements="*"/>
+    
+    <!-- isPartOf -->
+    <xsl:template name="isPartOf">
+            <xsl:variable name="setID" select="normalize-space(lower-case(.))"/>
+            <xsl:if test="$setID = $setSpecList/padig:set">
+                <xsl:element name="dcterms:isPartOf">
+                    <xsl:value-of select="$setSpecList/padig:set[. = $setID]/@string"/>
+                </xsl:element>
+            </xsl:if>
+    </xsl:template>
+    
+    <!-- dataProvider -->
+    <xsl:template name="dataProvider">
+        <xsl:variable name="baseURL" select='substring-before(.,"cdm/ref/")'/>
+        <xsl:if test="$baseURL = $oaiUrl/padig:url">
+            <xsl:element name="edm:dataProvider">
+                <xsl:value-of select="$oaiUrl/padig:url[. = $baseURL]/@string"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+    
+    <!-- identifier -->
+    <xsl:template name="identifier">
+        <xsl:variable name="itemID" select='substring-after(.,"/id/")'/>
+        <xsl:variable name="colID" select='substring-before(substring-after(.,"collection/"), "/id")'/>
+        <xsl:variable name="baseURL" select='substring-before(.,"cdm/ref/")'/>
+        
+        <xsl:element name="dcterms:identifier">
+            <xsl:value-of>padig:</xsl:value-of><xsl:value-of select="$oaiUrl/padig:url[. = $baseURL]/@code"/><xsl:value-of>-</xsl:value-of><xsl:value-of select="$colID"/><xsl:value-of>-</xsl:value-of><xsl:value-of select="$itemID"/>
+        </xsl:element>
+    </xsl:template>
+    
+    <!-- isShownAt -->
+    <xsl:template name="isShownAt">
+        <xsl:element name="edm:isShownAt">
+            <xsl:value-of select="normalize-space(.)"/>
+        </xsl:element>
+    </xsl:template>
+    
+    <!-- preview -->
+    <xsl:template name="preview">
+        <xsl:variable name="baseURL" select='substring-before(.,"cdm/ref/")'/>
+        <xsl:variable name="objID" select='substring-after(.,"/cdm/ref/")'/>
+        
+        <xsl:element name="edm:preview">
+            <xsl:value-of select="$baseURL"/> <xsl:text>utils/getthumbnail/</xsl:text><xsl:value-of select="$objID"/>
+        </xsl:element>
+    </xsl:template>
+    
+    <!-- iiifBase -->
+    <xsl:template name="iiifBase">
+        <xsl:variable name="baseURL" select='substring-before(.,"cdm/ref/")'/>
+        <xsl:variable name="itemID" select='substring-after(.,"/id/")'/>
+        <xsl:variable name="colID" select='substring-before(substring-after(.,"collection/"), "/id")'/>
+        
+        <xsl:element name="svcs:hasService">
+            <xsl:value-of select="$baseURL"/> <xsl:text>digital/iiif/</xsl:text><xsl:value-of select="$colID"/><xsl:text>/</xsl:text><xsl:value-of select="$itemID"/>
+        </xsl:element>
+    </xsl:template>
+    
+    <!-- iiifManifest -->
+    <xsl:template name="iiifManifest">
+        <xsl:variable name="baseURL" select='substring-before(.,"cdm/ref/")'/>
+        <xsl:variable name="itemID" select='substring-after(.,"/id/")'/>
+        <xsl:variable name="colID" select='substring-before(substring-after(.,"collection/"), "/id")'/>
+        
+        <xsl:element name="dcterms:isReferencedBy">
+            <xsl:value-of select="$baseURL"/> <xsl:text>iiif/info/</xsl:text><xsl:value-of select="$colID"/><xsl:text>/</xsl:text><xsl:value-of select="$itemID"/><xsl:text>/manifest.json</xsl:text>
+        </xsl:element>
+    </xsl:template>  
+</xsl:stylesheet>

--- a/transforms/cdm_pennstate.xsl
+++ b/transforms/cdm_pennstate.xsl
@@ -21,7 +21,29 @@
 
     <!-- Use includes here if you need to separate out templates for either use specific to a dataset or use generic enough for multiple providers (like remediation.xslt). -->
 
-    <xsl:include href="cdm_generic.xsl"/>
+    <xsl:include href="oai_base_crosswalk.xsl"/>
+    <xsl:include href="cdm_generic_templates.xsl"/>
+
+    <!-- Create collection name -->
+    
+    <xsl:template match="oai:header/oai:setSpec">
+            <xsl:call-template name="isPartOf"/>
+    </xsl:template>
+
+    <!-- Identifier templates, with Penn State content warning logic for preview -->
+
+    <xsl:template match="dc:identifier[position() = last()]">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:call-template name="dataProvider"/>
+            <xsl:call-template name="identifier"/>
+            <xsl:call-template name="isShownAt"/>
+            <xsl:if test="not(../dcterms:audience[text() = 'true'])">
+                <xsl:call-template name="preview"/>
+                <xsl:call-template name="iiifBase"/>
+                <xsl:call-template name="iiifManifest"/>
+            </xsl:if>
+        </xsl:if>
+    </xsl:template>
     
     <!-- medium to type -->
     <xsl:template match="dcterms:medium">
@@ -68,4 +90,14 @@
             </xsl:choose>
         </xsl:if>
     </xsl:template>
+
+    <!-- Penn State content warning description -->
+    <xsl:template match="dcterms:audience">
+        <xsl:if test=". = 'true'">
+            <xsl:element name="dcterms:description">
+                <xsl:value-of>The following item contains content that may be offensive or upsetting.</xsl:value-of>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+      
 </xsl:stylesheet>


### PR DESCRIPTION
Content warning flag is mapped from dcterms:audience. When content warning is true, we add a description field and suppress image-related links/identifiers. 

To do this, I pulled the templates out of cdm_generic.xsl and created cdm_generic_templates.xsl, so that they can be applied with custom logic for non-generic cdm stylesheets.