### PR TITLE
pd-396 update Temple type mappings

### DIFF
--- a/tests/xslt/cdm_temple.xspec
+++ b/tests/xslt/cdm_temple.xspec
@@ -510,6 +510,7 @@
            <dcterms:subject>DiLacqua, Peter</dcterms:subject>
            <dcterms:description>A citizen stands up in a meeting, to voice his opposition to a proposed disco hall.</dcterms:description>
            <schema:fileFormat>image/jp2</schema:fileFormat>
+           <dcterms:type>Still Image</dcterms:type>
            <dcterms:format>Photographs</dcterms:format>
            <dcterms:type>Image</dcterms:type>
            <dcterms:type>Still Image</dcterms:type>
@@ -548,6 +549,7 @@
           <dcterms:format>oranges</dcterms:format>
           <dcterms:type>Image</dcterms:type>
           <dcterms:type>Text</dcterms:type>
+          <dcterms:type>Still Image</dcterms:type>
           <dcterms:format>photographs</dcterms:format>
           <edm:provider>PA Digital</edm:provider>
         </oai_dc:dc>
@@ -967,6 +969,294 @@
         <x:expect label="Output record dcterms:format is original value" test="oai_dc:dc/dcterms:format = 'hello-interactive-resource'" />
         <x:expect label="Output record dcterms:type does not exist" test="not(oai_dc:dc/dcterms:type)" />
       </x:scenario>
+      
+      <x:scenario label="Supplemental Type Remediation: Administrative Records">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Administrative Records</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Text'" test="oai_dc:dc/dcterms:type = 'Text'" />
+        <x:expect label="Output record dcterms:format is 'Administrative Records'" test="oai_dc:dc/dcterms:format = 'Administrative Records'" />
+      </x:scenario>
+      <x:scenario label="Supplemental Type Remediation: Books">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Books</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Text'" test="oai_dc:dc/dcterms:type = 'Text'" />
+        <x:expect label="Output record dcterms:format is 'Books'" test="oai_dc:dc/dcterms:format = 'Books'" />
+      </x:scenario>
+      <x:scenario label="Supplemental Type Remediation: Clippings">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Clippings</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Text'" test="oai_dc:dc/dcterms:type = 'Text'" />
+        <x:expect label="Output record dcterms:format is 'Clippings'" test="oai_dc:dc/dcterms:format = 'Clippings'" />
+      </x:scenario>
+      <x:scenario label="Supplemental Type Remediation: Course Catalogs">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Course Catalogs</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Text'" test="oai_dc:dc/dcterms:type = 'Text'" />
+        <x:expect label="Output record dcterms:format is 'Course Catalogs'" test="oai_dc:dc/dcterms:format = 'Course Catalogs'" />
+      </x:scenario>
+      <x:scenario label="Supplemental Type Remediation: Correspondence">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Correspondence</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Text'" test="oai_dc:dc/dcterms:type = 'Text'" />
+        <x:expect label="Output record dcterms:format is 'Correspondence'" test="oai_dc:dc/dcterms:format = 'Correspondence'" />
+      </x:scenario>
+      <x:scenario label="Supplemental Type Remediation: Ephemera">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Ephemera</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Text'" test="oai_dc:dc/dcterms:type = 'Text'" />
+        <x:expect label="Output record dcterms:format is 'Ephemera'" test="oai_dc:dc/dcterms:format = 'Ephemera'" />
+      </x:scenario>
+      <x:scenario label="Supplemental Type Remediation: Financial Records">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Financial Records</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Text'" test="oai_dc:dc/dcterms:type = 'Text'" />
+        <x:expect label="Output record dcterms:format is 'Financial Records'" test="oai_dc:dc/dcterms:format = 'Financial Records'" />
+      </x:scenario>
+      <x:scenario label="Supplemental Type Remediation: Graphic Arts">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Graphic Arts</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Image'" test="oai_dc:dc/dcterms:type = 'Image'" />
+        <x:expect label="Output record dcterms:format is 'Graphic Arts'" test="oai_dc:dc/dcterms:format = 'Graphic Arts'" />
+      </x:scenario>
+      <x:scenario label="Supplemental Type Remediation: Manuscripts">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Manuscripts</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Text'" test="oai_dc:dc/dcterms:type = 'Text'" />
+        <x:expect label="Output record dcterms:format is 'Manuscripts'" test="oai_dc:dc/dcterms:format = 'Manuscripts'" />
+      </x:scenario>
+      <x:scenario label="Supplemental Type Remediation: Maps">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Maps</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Image'" test="oai_dc:dc/dcterms:type = 'Image'" />
+        <x:expect label="Output record dcterms:format is 'Maps'" test="oai_dc:dc/dcterms:format = 'Maps'" />
+      </x:scenario>
+      <x:scenario label="Supplemental Type Remediation: Objects">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Objects</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Physical Object'" test="oai_dc:dc/dcterms:type = 'Physical Object'" />
+        <x:expect label="Output record dcterms:format is 'Maps'" test="oai_dc:dc/dcterms:format = 'Objects'" />
+      </x:scenario>
+      <x:scenario label="Supplemental Type Remediation: Pamphlets">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Pamphlets</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Text'" test="oai_dc:dc/dcterms:type = 'Text'" />
+        <x:expect label="Output record dcterms:format is 'Pamphlets'" test="oai_dc:dc/dcterms:format = 'Pamphlets'" />
+      </x:scenario>
+      <x:scenario label="Supplemental Type Remediation: Periodicals">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Periodicals</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Text'" test="oai_dc:dc/dcterms:type = 'Text'" />
+        <x:expect label="Output record dcterms:format is 'Periodicals'" test="oai_dc:dc/dcterms:format = 'Periodicals'" />
+      </x:scenario>
+      <x:scenario label="Supplemental Type Remediation: Photographs">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Photographs</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Still Image'" test="oai_dc:dc/dcterms:type = 'Still Image'" />
+        <x:expect label="Output record dcterms:format is 'Photographs'" test="oai_dc:dc/dcterms:format = 'Photographs'" />
+      </x:scenario>
+      <x:scenario label="Supplemental Type Remediation: Posters">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Posters</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Still Image'" test="oai_dc:dc/dcterms:type = 'Still Image'" />
+        <x:expect label="Output record dcterms:format is 'Posters'" test="oai_dc:dc/dcterms:format = 'Posters'" />
+      </x:scenario>
+      <x:scenario label="Supplemental Type Remediation: Publications">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Publications</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Text'" test="oai_dc:dc/dcterms:type = 'Text'" />
+        <x:expect label="Output record dcterms:format is 'Publications'" test="oai_dc:dc/dcterms:format = 'Publications'" />
+      </x:scenario>
+      <x:scenario label="Supplemental Type Remediation: Reports">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Reports</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Text'" test="oai_dc:dc/dcterms:type = 'Text'" />
+        <x:expect label="Output record dcterms:format is 'Reports'" test="oai_dc:dc/dcterms:format = 'Reports'" />
+      </x:scenario>
+      <x:scenario label="Supplemental Type Remediation: Sheet Music">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Sheet Music</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Image'" test="oai_dc:dc/dcterms:type = 'Image'" />
+        <x:expect label="Output record dcterms:format is 'Sheet Music'" test="oai_dc:dc/dcterms:format = 'Sheet Music'" />
+      </x:scenario>
+      <x:scenario label="Supplemental Type Remediation: Slides">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Slides</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Still Image'" test="oai_dc:dc/dcterms:type = 'Still Image'" />
+        <x:expect label="Output record dcterms:format is 'Slides'" test="oai_dc:dc/dcterms:format = 'Slides'" />
+      </x:scenario>
+      <x:scenario label="Supplemental Type Remediation: Transcripts">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Transcripts</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Text'" test="oai_dc:dc/dcterms:type = 'Text'" />
+        <x:expect label="Output record dcterms:format is 'Transcripts'" test="oai_dc:dc/dcterms:format = 'Transcripts'" />
+      </x:scenario>
+      <x:scenario label="Supplemental Type Remediation: Video Recordings">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Video recordings</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Moving Image'" test="oai_dc:dc/dcterms:type = 'Moving Image'" />
+        <x:expect label="Output record dcterms:format is 'Transcripts'" test="oai_dc:dc/dcterms:format = 'Video recordings'" />
+      </x:scenario>
+      <x:scenario label="Supplemental Type Remediation: Yearbooks">
+        <x:context>
+          <oai:record>
+            <metadata>
+              <oai_qdc:qualifieddc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <dc:type>Yearbooks</dc:type>
+              </oai_qdc:qualifieddc>
+            </metadata>
+          </oai:record>
+        </x:context>
+        <x:expect label="Output record dcterms:type is 'Text'" test="oai_dc:dc/dcterms:type = 'Text'" />
+        <x:expect label="Output record dcterms:format is 'Yearbooks'" test="oai_dc:dc/dcterms:format = 'Yearbooks'" />
+      </x:scenario>
+      
     </x:scenario>
   </x:scenario>
 
@@ -1119,6 +1409,7 @@
          <dcterms:subject>DiLacqua, Peter</dcterms:subject>
          <dcterms:description>A citizen stands up in a meeting, to voice his opposition to a proposed disco hall.</dcterms:description>
          <schema:fileFormat>image/jp2</schema:fileFormat>
+         <dcterms:type>Still Image</dcterms:type>
          <dcterms:format>Photographs</dcterms:format>
          <dcterms:type>Image</dcterms:type>
          <dcterms:type>Still Image</dcterms:type>
@@ -1225,6 +1516,7 @@
          <dcterms:subject>DiLacqua, Peter</dcterms:subject>
          <dcterms:description>A citizen stands up in a meeting, to voice his opposition to a proposed disco hall.</dcterms:description>
          <schema:fileFormat>image/jp2</schema:fileFormat>
+         <dcterms:type>Still Image</dcterms:type>
          <dcterms:format>Photographs</dcterms:format>
          <dcterms:type>Image</dcterms:type>
          <dcterms:type>Still Image</dcterms:type>
@@ -1270,6 +1562,7 @@
            <dcterms:subject>DiLacqua, Peter</dcterms:subject>
            <dcterms:description>A citizen stands up in a meeting, to voice his opposition to a proposed disco hall.</dcterms:description>
            <schema:fileFormat>image/jp2</schema:fileFormat>
+           <dcterms:type>Still Image</dcterms:type>
            <dcterms:format>Photographs</dcterms:format>
            <dcterms:type>Image</dcterms:type>
            <dcterms:type>Still Image</dcterms:type>
@@ -1437,6 +1730,7 @@
              <dcterms:subject>DiLacqua, Peter</dcterms:subject>
              <dcterms:description>A citizen stands up in a meeting, to voice his opposition to a proposed disco hall.</dcterms:description>
              <schema:fileFormat>image/jp2</schema:fileFormat>
+             <dcterms:type>Still Image</dcterms:type>
              <dcterms:format>Photographs</dcterms:format>
              <dcterms:type>Image</dcterms:type>
              <dcterms:type>Still Image</dcterms:type>

--- a/transforms/cdm_temple.xsl
+++ b/transforms/cdm_temple.xsl
@@ -46,6 +46,16 @@
             <xsl:call-template name="iiifBase"/>
             <xsl:call-template name="iiifManifest"/>
         </xsl:if>
+    </xsl:template> 
+    
+    <!-- Supplemental Type and Format -->
+    <xsl:template match="dc:type" priority="1">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:call-template name="supplemental_type_template">
+                <xsl:with-param name="strings" select="replace(normalize-space(.),'&amp;amp;','&amp;')"/>
+                <xsl:with-param name="delimiter" select="';'"/>
+            </xsl:call-template>
+        </xsl:if>
     </xsl:template>
     
     <!-- templates -->
@@ -120,4 +130,271 @@
             <xsl:value-of select="$baseURL"/> <xsl:text>iiif/info/</xsl:text><xsl:value-of select="$colID"/><xsl:text>/</xsl:text><xsl:value-of select="$itemID"/><xsl:text>/manifest.json</xsl:text>
         </xsl:element>
     </xsl:template>  
+    
+    <!-- Supplemental Type Template for Temple -->
+    
+    <xsl:template name="supplemental_type_template">
+        <xsl:param name="strings"/>
+        <xsl:param name="delimiter"/>
+        
+        <xsl:choose>
+            <!-- IF A PAREN, STOP AT AN OPENING semicolon -->
+            <xsl:when test="contains($strings, $delimiter)">
+                <xsl:variable name="newstem" select="normalize-space(substring-after($strings, $delimiter))"/>
+                <xsl:variable name="firststem" select="normalize-space(substring-before($strings, $delimiter))"/>
+                <xsl:choose>
+                    <xsl:when test="matches($firststem, '(^text.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '(^image.*$)', 'i')">
+                        <dcterms:type>Image</dcterms:type>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '^(movingimage.*$|moving\simage.*$)', 'i')">
+                        <dcterms:type>Moving Image</dcterms:type>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '^(sound.*$)', 'i')">
+                        <dcterms:type>Sound</dcterms:type>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '^(physicalobject.*$|physical\sobject.*$)', 'i')">
+                        <dcterms:type>Physical Object</dcterms:type>
+                    </xsl:when>
+                    <xsl:when
+                        test="matches($firststem, '^(interactiveresource.*$|interactive\sresource.*$)', 'i')">
+                        <dcterms:type>Interactive Resource</dcterms:type>
+                    </xsl:when>
+                    <xsl:when
+                        test="matches($firststem, '^(stillimage.*$|still\simage.*$)', 'i')">
+                        <dcterms:type>Still Image</dcterms:type>
+                    </xsl:when>
+                    <!-- Temple customization starts here -->
+                    <xsl:when test="matches($firststem, '(^administrativerecord.*$|administrative\srecord.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '(^book.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '(^clipping.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '(^coursecatalog.*$|course\scatalog.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '(^correspondence.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '(^ephemera.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '(^financialrecord.*$|financial\srecord)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '(^graphicart.*$|graphic\sart.*$)', 'i')">
+                        <dcterms:type>Image</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '(^manuscript.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '(^map.*$)', 'i')">
+                        <dcterms:type>Image</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '(^object.*$)', 'i')">
+                        <dcterms:type>Physical Object</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '(^pamphlet.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '(^periodical.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '(^photograph.*$)', 'i')">
+                        <dcterms:type>Still Image</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '(^poster.*$)', 'i')">
+                        <dcterms:type>Still Image</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '(^publication.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '(^report.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '(^sheetmusic.*$|sheet\smusic.*$)', 'i')">
+                        <dcterms:type>Image</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '(^slide.*$)', 'i')">
+                        <dcterms:type>Still Image</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when> 
+                    <xsl:when test="matches($firststem, '(^transcript.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '(^video.*$)', 'i')">
+                        <dcterms:type>Moving Image</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($firststem, '(^yearbook.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($firststem)"/></dcterms:format>
+                    </xsl:when>
+                    <!-- Format -->
+                    <xsl:otherwise>
+                        <xsl:if test="normalize-space($firststem)!=''">
+                            <dcterms:format>
+                                <xsl:value-of select="normalize-space($firststem)"/>
+                            </dcterms:format>
+                        </xsl:if>
+                    </xsl:otherwise>
+                </xsl:choose>
+                <!--Need to do recursion-->
+                <xsl:call-template name="supplemental_type_template">
+                    <xsl:with-param name="strings" select="$newstem"/>
+                    <xsl:with-param name="delimiter" select="';'"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:choose>
+                    <xsl:when test="matches($strings, '(^text.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^image.*$)', 'i')">
+                        <dcterms:type>Image</dcterms:type>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '^(movingimage.*$|moving\simage.*$)', 'i')">
+                        <dcterms:type>Moving Image</dcterms:type>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '^(sound.*$)', 'i')">
+                        <dcterms:type>Sound</dcterms:type>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '^(physicalobject.*$|physical\sobject.*$)', 'i')">
+                        <dcterms:type>Physical Object</dcterms:type>
+                    </xsl:when>
+                    <xsl:when
+                        test="matches($strings, '^(interactiveresource.*$|interactive\sresource.*$)', 'i')">
+                        <dcterms:type>Interactive Resource</dcterms:type>
+                    </xsl:when>
+                    <xsl:when
+                        test="matches($strings, '^(stillimage.*$|still\simage.*$)', 'i')">
+                        <dcterms:type>Still Image</dcterms:type>
+                    </xsl:when>
+                    <!-- Temple customization starts here -->
+                    <xsl:when test="matches($strings, '(^administrativerecord.*$|administrative\srecord.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^book.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^clipping.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^coursecatalog.*$|course\scatalog.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^correspondence.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^ephemera.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^financialrecord.*$|financial\srecord)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^graphicart.*$|graphic\sart.*$)', 'i')">
+                        <dcterms:type>Image</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^manuscript.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^map.*$)', 'i')">
+                        <dcterms:type>Image</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^object.*$)', 'i')">
+                        <dcterms:type>Physical Object</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^pamphlet.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^periodical.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^photograph.*$)', 'i')">
+                        <dcterms:type>Still Image</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^poster.*$)', 'i')">
+                        <dcterms:type>Still Image</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^publication.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^report.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^sheetmusic.*$|sheet\smusic.*$)', 'i')">
+                        <dcterms:type>Image</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^slide.*$)', 'i')">
+                        <dcterms:type>Still Image</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^transcript.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^video.*$)', 'i')">
+                        <dcterms:type>Moving Image</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <xsl:when test="matches($strings, '(^yearbook.*$)', 'i')">
+                        <dcterms:type>Text</dcterms:type>
+                        <dcterms:format><xsl:value-of select="normalize-space($strings)"/></dcterms:format>
+                    </xsl:when>
+                    <!-- Format -->
+                    <xsl:otherwise>
+                        <xsl:if test="normalize-space($strings)!=''">
+                            <dcterms:format>
+                                <xsl:value-of select="normalize-space($strings)"/>
+                            </dcterms:format>
+                        </xsl:if>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
 </xsl:stylesheet>


### PR DESCRIPTION
- adds supplemental type mappings for Temple transform

Note: This creates some potential duplication in Type terms based on the cdm_generic test fixture, but duplicate Type terms are unlikely to occur using Temple's actual data. Any actual duplicate values would be de-duped by DPLA so I don't think this does harm, but if you have suggestions for avoiding this please let me know. 